### PR TITLE
Optimize tdfparse

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,6 +761,7 @@ set(TEST_FILES
     src/rwe/io/gui/gui.test.cpp
     src/rwe/io/ota/ota.test.cpp
     src/rwe/io/tdf/ListTdfAdapter.test.cpp
+    src/rwe/io/tdf/NetSchemaTdfAdapter.test.cpp
     src/rwe/io/tdf/SimpleTdfAdapter.test.cpp
     src/rwe/io/tdf/TdfBlock.test.cpp
     src/rwe/ip_util.test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,8 @@ set(SOURCE_FILES
     src/rwe/io/pcx/pcx.h
     src/rwe/io/tdf/ListTdfAdapter.cpp
     src/rwe/io/tdf/ListTdfAdapter.h
+    src/rwe/io/tdf/NetSchemaTdfAdapter.cpp
+    src/rwe/io/tdf/NetSchemaTdfAdapter.h
     src/rwe/io/tdf/SimpleTdfAdapter.cpp
     src/rwe/io/tdf/SimpleTdfAdapter.h
     src/rwe/io/tdf/TdfBlock.cpp

--- a/src/rwe/MainMenuScene.cpp
+++ b/src/rwe/MainMenuScene.cpp
@@ -937,9 +937,6 @@ namespace rwe
             throw std::runtime_error("Failed to read OTA file");
         }
 
-        std::string otaStr(otaRaw->begin(), otaRaw->end());
-        auto ota = parseOta(parseTdfFromString(otaStr));
-
-        return std::any_of(ota.schemas.begin(), ota.schemas.end(), [](const auto& s) { return startsWith(toUpper(s.type), "NETWORK"); });
+        return parseTdfHasNetworkSchema(*otaRaw);
     }
 }

--- a/src/rwe/MainMenuScene.cpp
+++ b/src/rwe/MainMenuScene.cpp
@@ -723,14 +723,14 @@ namespace rwe
     {
         auto mapNames = sceneContext.vfs->getFileNames("maps", ".ota");
 
+        // Keep only maps that have a multiplayer schema
+        mapNames.erase(std::remove_if(mapNames.begin(), mapNames.end(), [this](const auto& e) { return !hasMultiplayerSchema(e); }), mapNames.end());
+
         for (auto& e : mapNames)
         {
             // chop off the extension
             e.resize(e.size() - 4);
         }
-
-        // Keep only maps that have a multiplayer schema
-        mapNames.erase(std::remove_if(mapNames.begin(), mapNames.end(), [this](const auto& e) { return !hasMultiplayerSchema(e); }), mapNames.end());
 
         return mapNames;
     }
@@ -931,7 +931,7 @@ namespace rwe
 
     bool MainMenuScene::hasMultiplayerSchema(const std::string& mapName)
     {
-        auto otaRaw = sceneContext.vfs->readFile(std::string("maps/").append(mapName).append(".ota"));
+        auto otaRaw = sceneContext.vfs->readFile(std::string("maps/").append(mapName));
         if (!otaRaw)
         {
             throw std::runtime_error("Failed to read OTA file");

--- a/src/rwe/io/tdf/NetSchemaTdfAdapter.cpp
+++ b/src/rwe/io/tdf/NetSchemaTdfAdapter.cpp
@@ -1,0 +1,35 @@
+#include "NetSchemaTdfAdapter.h"
+// Special case parsing, only checks if there's a schema with type "NETWORK" (when searching all maps, a full parse and validity check is expensive)
+
+namespace rwe
+{
+    void NetSchemaTdfAdapter::onStart()
+    {
+        bHasNetSchema = false;
+        bInSchema = false;
+    }
+
+    void NetSchemaTdfAdapter::onProperty(const std::string& name, const std::string& value)
+    {
+        // TODO (kwh) - ok ok this is ridiculous overkill. gives about 2.5% boost to loading the map list
+        bHasNetSchema |= bInSchema && name.size() == 4 && (name[0] == 'T' || name[0] == 't') && (name[1] == 'y' || name[1] == 'Y') && (name[2] == 'p' || name[2] == 'P') && (name[3] == 'e' || name[3] == 'E') && value.size() >= 7 && (value[0] == 'N' || value[0] == 'n') && (value[1] == 'e' || value[1] == 'E') && (value[2] == 't' || value[2] == 'T') && (value[3] == 'w' || value[3] == 'W') && (value[4] == 'o' || value[4] == 'O') && (value[5] == 'r' || value[5] == 'R') && (value[6] == 'k' || value[6] == 'K');
+        //bHasNetSchema |= bInSchema && toUpper(name) == "TYPE" && startsWith(toUpper(value), "NETWORK");
+    }
+
+    void NetSchemaTdfAdapter::onStartBlock(const std::string& name)
+    {
+        // Note: not checking for validity of the schema number (or if it even is a number). If we wanted to, we'd need to track if we're in GlobalHeader and get the SCHEMACOUNT property, and see if there's a number at the end of the schema type property...
+        bInSchema |= name.size() > 7 && (name[0] == 'S' || name[0] == 's') && (name[1] == 'c' || name[1] == 'C') && (name[2] == 'h' || name[2] == 'H') && (name[3] == 'e' || name[3] == 'E') && (name[4] == 'm' || name[4] == 'M') && (name[5] == 'a' || name[5] == 'A') && name[6] == ' ';
+        //bInSchema |= startsWith(toUpper(name), "SCHEMA "); 
+    }
+
+    void NetSchemaTdfAdapter::onEndBlock()
+    {
+        bInSchema = false;
+    }
+
+    NetSchemaTdfAdapter::Result NetSchemaTdfAdapter::onDone()
+    {
+        return bHasNetSchema;
+    }
+}

--- a/src/rwe/io/tdf/NetSchemaTdfAdapter.cpp
+++ b/src/rwe/io/tdf/NetSchemaTdfAdapter.cpp
@@ -5,31 +5,38 @@ namespace rwe
 {
     void NetSchemaTdfAdapter::onStart()
     {
-        bHasNetSchema = false;
-        bInSchema = false;
+        hasNetSchema = false;
+        schemaNestedLevel = -1; // when >= 0: we are in a schema block (or one of its children)
     }
 
     void NetSchemaTdfAdapter::onProperty(const std::string& name, const std::string& value)
     {
-        // TODO (kwh) - ok ok this is ridiculous overkill. gives about 2.5% boost to loading the map list
-        bHasNetSchema |= bInSchema && name.size() == 4 && (name[0] == 'T' || name[0] == 't') && (name[1] == 'y' || name[1] == 'Y') && (name[2] == 'p' || name[2] == 'P') && (name[3] == 'e' || name[3] == 'E') && value.size() >= 7 && (value[0] == 'N' || value[0] == 'n') && (value[1] == 'e' || value[1] == 'E') && (value[2] == 't' || value[2] == 'T') && (value[3] == 'w' || value[3] == 'W') && (value[4] == 'o' || value[4] == 'O') && (value[5] == 'r' || value[5] == 'R') && (value[6] == 'k' || value[6] == 'K');
-        //bHasNetSchema |= bInSchema && toUpper(name) == "TYPE" && startsWith(toUpper(value), "NETWORK");
+        hasNetSchema |= schemaNestedLevel >= 0 && toUpper(name) == "TYPE" && startsWith(toUpper(value), "NETWORK");
     }
 
     void NetSchemaTdfAdapter::onStartBlock(const std::string& name)
     {
+        if (schemaNestedLevel >= 0)
+        {
+            ++schemaNestedLevel;
+        }
         // Note: not checking for validity of the schema number (or if it even is a number). If we wanted to, we'd need to track if we're in GlobalHeader and get the SCHEMACOUNT property, and see if there's a number at the end of the schema type property...
-        bInSchema |= name.size() > 7 && (name[0] == 'S' || name[0] == 's') && (name[1] == 'c' || name[1] == 'C') && (name[2] == 'h' || name[2] == 'H') && (name[3] == 'e' || name[3] == 'E') && (name[4] == 'm' || name[4] == 'M') && (name[5] == 'a' || name[5] == 'A') && name[6] == ' ';
-        //bInSchema |= startsWith(toUpper(name), "SCHEMA "); 
+        else if (startsWith(toUpper(name), "SCHEMA "))
+        {
+            schemaNestedLevel = 0;
+        }
     }
 
     void NetSchemaTdfAdapter::onEndBlock()
     {
-        bInSchema = false;
+        if (schemaNestedLevel >= 0)
+        {
+            --schemaNestedLevel;
+        }
     }
 
     NetSchemaTdfAdapter::Result NetSchemaTdfAdapter::onDone()
     {
-        return bHasNetSchema;
+        return hasNetSchema;
     }
 }

--- a/src/rwe/io/tdf/NetSchemaTdfAdapter.h
+++ b/src/rwe/io/tdf/NetSchemaTdfAdapter.h
@@ -1,0 +1,23 @@
+#pragma once
+#include <rwe/io/tdf/TdfParser.h>
+#include <vector>
+
+namespace rwe
+{
+    class NetSchemaTdfAdapter : public TdfAdapter<bool>
+    {
+    private:
+        bool bHasNetSchema, bInSchema;
+
+    public:
+        void onStart() override;
+
+        void onProperty(const std::string& name, const std::string& value) override;
+
+        void onStartBlock(const std::string& name) override;
+
+        void onEndBlock() override;
+
+        Result onDone() override;
+    };
+}

--- a/src/rwe/io/tdf/NetSchemaTdfAdapter.h
+++ b/src/rwe/io/tdf/NetSchemaTdfAdapter.h
@@ -7,8 +7,8 @@ namespace rwe
     class NetSchemaTdfAdapter : public TdfAdapter<bool>
     {
     private:
-        bool bHasNetSchema, bInSchema;
-
+        bool hasNetSchema;
+        int schemaNestedLevel;
     public:
         void onStart() override;
 

--- a/src/rwe/io/tdf/NetSchemaTdfAdapter.test.cpp
+++ b/src/rwe/io/tdf/NetSchemaTdfAdapter.test.cpp
@@ -1,0 +1,171 @@
+#include <catch2/catch.hpp>
+#include <rwe/io/tdf/NetSchemaTdfAdapter.h>
+
+#include <utf8.h>
+
+#include <algorithm>
+#include <ostream>
+#include <vector>
+
+namespace rwe
+{
+    TEST_CASE("NetSchemaTdfAdapter")
+    {
+        TdfParser<std::string::const_iterator, bool> parser(new NetSchemaTdfAdapter);
+
+        SECTION("no schema, no network property")
+        {
+            std::string input = R"TDF(
+[Foo]
+{
+    Bar=1;
+    Baz=2;
+    Alice=Bob;
+}
+)TDF";
+
+            bool expected = false;
+            bool result = parser.parse(input.cbegin(), input.cend());
+
+            REQUIRE(result == expected);
+        }
+
+        SECTION("no schema, with network property")
+        {
+            std::string input = R"TDF(
+[Foo]
+{
+    Type=Network 1;
+    Baz=2;
+    Alice=Bob;
+}
+)TDF";
+
+            bool expected = false;
+            bool result = parser.parse(input.cbegin(), input.cend());
+
+            REQUIRE(result == expected);
+        }
+
+        SECTION("with schema, no network property")
+        {
+            std::string input = R"TDF(
+[Foo]
+    {
+    Bar=1;
+    Baz=2;
+    [Schema 1]
+        {
+        SurfaceMetal=4;
+        
+        [specials]
+            {
+            [special0]
+                {
+                specialwhat=StartPos1;
+                XPos=2260;
+                ZPos=4054;
+                }
+            }
+        }
+    }
+)TDF";
+
+            bool expected = false;
+            bool result = parser.parse(input.cbegin(), input.cend());
+
+            REQUIRE(result == expected);
+        }
+
+        SECTION("with schema, network property but not in schema")
+        {
+            std::string input = R"TDF(
+[Foo]
+    {
+    Bar=1;
+    Baz=2;
+    Type=Network 1;
+    [Schema 1]
+        {
+        SurfaceMetal=4;
+        
+        [specials]
+            {
+            [special0]
+                {
+                specialwhat=StartPos1;
+                XPos=2260;
+                ZPos=4054;
+                }
+            }
+        }
+    }
+)TDF";
+
+            bool expected = false;
+            bool result = parser.parse(input.cbegin(), input.cend());
+
+            REQUIRE(result == expected);
+        }
+
+        SECTION("schema with network property before nested block")
+        {
+            std::string input = R"TDF(
+[Foo]
+    {
+    Bar=1;
+    Baz=2;
+    [Schema 1]
+        {
+        SurfaceMetal=4;
+        Type=Network 1;
+        [specials]
+            {
+            [special0]
+                {
+                specialwhat=StartPos1;
+                XPos=2260;
+                ZPos=4054;
+                }
+            }
+        }
+    }
+)TDF";
+
+            bool expected = true;
+            bool result = parser.parse(input.cbegin(), input.cend());
+
+            REQUIRE(result == expected);
+        }
+
+        SECTION("schema with network property after nested block")
+        {
+            std::string input = R"TDF(
+[Foo]
+{
+    Bar=1;
+    Baz=2;
+    [Schema 1]
+    {
+        SurfaceMetal=4;
+        [specials]
+        {
+            [special0]
+            {
+                specialwhat=StartPos1;
+                XPos=2260;
+                ZPos=4054;
+            }
+        }
+        Type=Network 1;
+    }
+}
+)TDF";
+
+            bool expected = true;
+            bool result = parser.parse(input.cbegin(), input.cend());
+
+            REQUIRE(result == expected);
+        }
+    }
+}

--- a/src/rwe/io/tdf/TdfParser.h
+++ b/src/rwe/io/tdf/TdfParser.h
@@ -171,12 +171,12 @@ namespace rwe
             consumeComments();
             while (*_it != ']' && *_it != TdfEndOfFile)
             {
-                utf8::append(*_it, inserter);
-                consumeComments();
+                utf8::unchecked::append(*_it, inserter);
                 ++_it;
+                consumeComments();
             }
 
-            utf8Trim(name);
+            utf8UncheckedTrim(name);
 
             return name;
         }
@@ -230,19 +230,19 @@ namespace rwe
                 throw TdfParserException(_it.getLine(), _it.getColumn(), "Expected property name");
             }
 
-            utf8::append(*_it, inserter);
+            utf8::unchecked::append(*_it, inserter);
             ++_it;
 
             consumeComments();
 
             while (*_it != '=' && *_it != ';' && *_it != TdfEndOfFile)
             {
-                utf8::append(*_it, inserter);
+                utf8::unchecked::append(*_it, inserter);
                 ++_it;
                 consumeComments();
             }
 
-            utf8Trim(value);
+            utf8UncheckedTrim(value);
 
             return value;
         }
@@ -254,12 +254,12 @@ namespace rwe
 
             while (*_it != ';' && *_it != TdfEndOfFile)
             {
-                utf8::append(*_it, inserter);
+                utf8::unchecked::append(*_it, inserter);
                 ++_it;
                 consumeComments();
             }
 
-            utf8Trim(value);
+            utf8UncheckedTrim(value);
 
             return value;
         }

--- a/src/rwe/io/tdf/tdf.cpp
+++ b/src/rwe/io/tdf/tdf.cpp
@@ -2,43 +2,44 @@
 
 #include <rwe/io/tdf/ListTdfAdapter.h>
 #include <rwe/io/tdf/SimpleTdfAdapter.h>
+#include <rwe/io/tdf/NetSchemaTdfAdapter.h>
 
 namespace rwe
 {
-    TdfBlock parseTdf(ConstUtf8Iterator& begin, ConstUtf8Iterator& end)
+    bool parseTdfHasNetworkSchema(const std::vector<char>& input)
     {
-        TdfParser<ConstUtf8Iterator, TdfBlock> parser(new SimpleTdfAdapter);
-        return parser.parse(begin, end);
+        TdfParser<std::vector<char>::const_iterator, bool> parser(new NetSchemaTdfAdapter);
+        return parser.parse(input.begin(), input.end());
     }
 
     TdfBlock parseTdfFromString(const std::string& input)
     {
-        TdfParser<ConstUtf8Iterator, TdfBlock> parser(new SimpleTdfAdapter);
+        TdfParser<ConstUtf8UncheckedIterator, TdfBlock> parser(new SimpleTdfAdapter);
 
         // TA files typically use legacy ISO-8859-1 encoding (latin1)
         // so fall back to that if the input isn't valid UTF8.
         if (!utf8::is_valid(input.begin(), input.end()))
         {
             auto convertedInput = latin1ToUtf8(input);
-            return parser.parse(cUtf8Begin(convertedInput), cUtf8End(convertedInput));
+            return parser.parse(cUtf8UncheckedBegin(convertedInput), cUtf8UncheckedEnd(convertedInput));
         }
 
-        return parser.parse(cUtf8Begin(input), cUtf8End(input));
+        return parser.parse(cUtf8UncheckedBegin(input), cUtf8UncheckedEnd(input));
     }
 
     std::vector<TdfBlock> parseListTdfFromString(const std::string& input)
     {
-        TdfParser<ConstUtf8Iterator, std::vector<TdfBlock>> parser(new ListTdfAdapter);
+        TdfParser<ConstUtf8UncheckedIterator, std::vector<TdfBlock>> parser(new ListTdfAdapter);
 
         // TA files typically use legacy ISO-8859-1 encoding (latin1)
         // so fall back to that if the input isn't valid UTF8.
         if (!utf8::is_valid(input.begin(), input.end()))
         {
             auto convertedInput = latin1ToUtf8(input);
-            return parser.parse(cUtf8Begin(convertedInput), cUtf8End(convertedInput));
+            return parser.parse(cUtf8UncheckedBegin(convertedInput), cUtf8UncheckedEnd(convertedInput));
         }
 
-        return parser.parse(cUtf8Begin(input), cUtf8End(input));
+        return parser.parse(cUtf8UncheckedBegin(input), cUtf8UncheckedEnd(input));
     }
 
     TdfBlock parseTdfFromBytes(const std::vector<char>& bytes)

--- a/src/rwe/io/tdf/tdf.h
+++ b/src/rwe/io/tdf/tdf.h
@@ -2,9 +2,12 @@
 
 #include <rwe/io/tdf/TdfBlock.h>
 #include <rwe/rwe_string.h>
+#include <vector>
 
 namespace rwe
 {
+    bool parseTdfHasNetworkSchema(const std::vector<char>& input);
+
     TdfBlock parseTdf(ConstUtf8Iterator& begin, ConstUtf8Iterator& end);
 
     TdfBlock parseTdfFromString(const std::string& input);

--- a/src/rwe/rwe_string.cpp
+++ b/src/rwe/rwe_string.cpp
@@ -68,6 +68,27 @@ namespace rwe
         return copy;
     }
 
+    // Note: unchecked iterators should only be used on input that would pass utf8::is_valid check
+    ConstUtf8UncheckedIterator cUtf8UncheckedBegin(const std::string& str)
+    {
+        return utf8::unchecked::iterator<std::string::const_iterator>(str.begin());
+    }
+
+    ConstUtf8UncheckedIterator cUtf8UncheckedEnd(const std::string& str)
+    {
+        return utf8::unchecked::iterator<std::string::const_iterator>(str.end());
+    }
+
+    Utf8UncheckedIterator utf8UncheckedBegin(std::string& str)
+    {
+        return utf8::unchecked::iterator<std::string::iterator>(str.begin());
+    }
+
+    Utf8UncheckedIterator utf8UncheckedEnd(std::string& str)
+    {
+        return utf8::unchecked::iterator<std::string::iterator>(str.end());
+    }
+
     ConstUtf8Iterator utf8Begin(const std::string& str)
     {
         return utf8::iterator<std::string::const_iterator>(str.begin(), str.begin(), str.end());
@@ -123,6 +144,33 @@ namespace rwe
     {
         utf8TrimRight(str);
         utf8TrimLeft(str);
+    }
+
+    void utf8UncheckedTrimLeft(std::string& str)
+    {
+        auto firstNonSpace = std::find_if(utf8UncheckedBegin(str), utf8UncheckedEnd(str), [](unsigned int cp) { return std::isspace(cp) == 0; });
+        str.erase(str.begin(), firstNonSpace.base());
+    }
+
+    void utf8UncheckedTrimRight(std::string& str)
+    {
+        auto it = utf8UncheckedEnd(str);
+        auto begin = utf8UncheckedBegin(str);
+        while (it != begin)
+        {
+            if (std::isspace(*--it) == 0)
+            {
+                ++it;
+                str.erase(it.base(), str.end());
+                return;
+            }
+        }
+    }
+
+    void utf8UncheckedTrim(std::string& str)
+    {
+        utf8UncheckedTrimRight(str);
+        utf8UncheckedTrimLeft(str);
     }
 
     bool endsWith(const std::string& str, const std::string& end)

--- a/src/rwe/rwe_string.h
+++ b/src/rwe/rwe_string.h
@@ -9,6 +9,9 @@
 
 namespace rwe
 {
+    using ConstUtf8UncheckedIterator = utf8::unchecked::iterator<std::string::const_iterator>;
+    using Utf8UncheckedIterator = utf8::unchecked::iterator<std::string::iterator>;
+
     using ConstUtf8Iterator = utf8::iterator<std::string::const_iterator>;
     using Utf8Iterator = utf8::iterator<std::string::iterator>;
 
@@ -24,6 +27,11 @@ namespace rwe
 
     std::string toUpper(const std::string& str);
 
+    ConstUtf8UncheckedIterator cUtf8UncheckedBegin(const std::string& str);
+    ConstUtf8UncheckedIterator cUtf8UncheckedEnd(const std::string& str);
+    Utf8UncheckedIterator utf8UncheckedBegin(const std::string& str);
+    Utf8UncheckedIterator utf8UncheckedEnd(const std::string& str);
+
     Utf8Iterator utf8Begin(std::string& str);
     ConstUtf8Iterator utf8Begin(const std::string& str);
     ConstUtf8Iterator cUtf8Begin(const std::string& str);
@@ -35,6 +43,10 @@ namespace rwe
     void utf8TrimLeft(std::string& str);
     void utf8TrimRight(std::string& str);
     void utf8Trim(std::string& str);
+
+    void utf8UncheckedTrimLeft(std::string& str);
+    void utf8UncheckedTrimRight(std::string& str);
+    void utf8UncheckedTrim(std::string& str);
 
     bool startsWith(const std::string& str, const std::string& prefix);
     bool endsWith(const std::string& str, const std::string& end);

--- a/src/rwe/rwe_string.test.cpp
+++ b/src/rwe/rwe_string.test.cpp
@@ -78,12 +78,22 @@ namespace rwe
         }
     }
 
-    TEST_CASE("utf8Trim")
+    TEST_CASE("utf8TrimChecked")
     {
         SECTION("trims leading and trailing spaces")
         {
             std::string s("    foo  ");
             utf8Trim(s);
+            REQUIRE(s == "foo");
+        }
+    }
+
+    TEST_CASE("utf8TrimUnchecked")
+    {
+        SECTION("trims leading and trailing spaces")
+        {
+            std::string s("    foo  ");
+            utf8UncheckedTrim(s);
             REQUIRE(s == "foo");
         }
     }


### PR DESCRIPTION
I optimized the inner loops of tdfparser a bit more, and properly did unchecked utf8 iterators in the parser.
Then, I realized tdf parsing only happens during init, and this is really only a problem for the case where we select maps, given there are a lot of maps. In that particular case, we are only looking for one field: a schema with type "Network". So I made a TdfAdapter for the parser that doesn't store any strings and only outputs a bool if it finds a schema with type "Network", and give it a simple vector<char> iterator.  All together, that speeds things by about 90% - (debug from 5m down to 30s).

I'm skipping the utf8::is_valid here, otherwise basically running the parser equally apart from the barebones adapter, and profiling shows maybe 1/3 of the time now is spent in utf8::append and utf8Trim, which I don't think are necessary for this case, but to remove those would require special casing a larger portion of the parser.