### PR TITLE
Handle escape key

### DIFF
--- a/src/rwe/GameScene.cpp
+++ b/src/rwe/GameScene.cpp
@@ -914,6 +914,10 @@ namespace rwe
         {
             rightShiftDown = true;
         }
+        else if (keysym.sym == SDLK_ESCAPE)
+        {
+          clearUnitSelection();
+        }
         else if (keysym.sym == SDLK_F11)
         {
             showDebugWindow = true;

--- a/src/rwe/GameScene.cpp
+++ b/src/rwe/GameScene.cpp
@@ -916,7 +916,7 @@ namespace rwe
         }
         else if (keysym.sym == SDLK_ESCAPE)
         {
-          clearUnitSelection();
+            handleEscapeDown();
         }
         else if (keysym.sym == SDLK_F11)
         {
@@ -2356,6 +2356,17 @@ namespace rwe
     bool GameScene::isShiftDown() const
     {
         return leftShiftDown || rightShiftDown;
+    }
+
+    void GameScene::handleEscapeDown() {
+        match(
+            cursorMode.getValue(),
+            [this](const NormalCursorMode&) {
+                clearUnitSelection();
+            },
+            [this](const auto&) {
+                cursorMode.next(NormalCursorMode());
+            });
     }
 
     Unit& GameScene::getUnit(UnitId id)

--- a/src/rwe/GameScene.h
+++ b/src/rwe/GameScene.h
@@ -446,6 +446,8 @@ namespace rwe
 
         bool isShiftDown() const;
 
+        void handleEscapeDown();
+
         Unit& getUnit(UnitId id);
 
         const Unit& getUnit(UnitId id) const;


### PR DESCRIPTION
Allows units to be deselected with the escape key.
Edit: If the current cursor mode is not normal, pressing escape will return to the normal cursor mode.