### PR TITLE
Variable energy and metal storage

### DIFF
--- a/src/rwe/GameScene.cpp
+++ b/src/rwe/GameScene.cpp
@@ -1640,7 +1640,7 @@ namespace rwe
         return unitId;
     }
 
-    void GameScene::spawnCompletedUnit(const std::string& unitType, PlayerId owner, const SimVector& position)
+    std::optional<std::reference_wrapper<Unit>> GameScene::spawnCompletedUnit(const std::string& unitType, PlayerId owner, const SimVector& position)
     {
         auto unitId = spawnUnit(unitType, owner, position, std::nullopt);
         if (unitId)
@@ -1649,7 +1649,11 @@ namespace rwe
             // units start as unbuilt nanoframes,
             // we we need to convert it immediately into a completed unit.
             unit.finishBuilding();
+
+            return unit;
         }
+
+        return std::nullopt;
     }
 
     void GameScene::setCameraPosition(const Vector3f& newPosition)
@@ -1980,6 +1984,23 @@ namespace rwe
         // run resource updates once per second
         if (simulation.gameTime % GameTime(SimTicksPerSecond) == GameTime(0))
         {
+            // recalculate max energy and metal storage
+            for (auto& player : simulation.players)
+            {
+                player.maxEnergy = Energy(0);
+                player.maxMetal = Metal(0);
+            }
+
+            for (auto& entry : simulation.units)
+            {
+                auto& unit = entry.second;
+                if (!unit.isBeingBuilt())
+                {
+                    getPlayer(unit.owner).maxMetal += unit.metalStorage;
+                    getPlayer(unit.owner).maxEnergy += unit.energyStorage;
+                }
+            }
+
             for (auto& player : simulation.players)
             {
                 player.metal += player.metalProductionBuffer;
@@ -2372,6 +2393,11 @@ namespace rwe
     std::optional<std::reference_wrapper<const Unit>> GameScene::tryGetUnit(UnitId id) const
     {
         return simulation.tryGetUnit(id);
+    }
+
+    GamePlayerInfo& GameScene::getPlayer(PlayerId player)
+    {
+        return simulation.getPlayer(player);
     }
 
     const GamePlayerInfo& GameScene::getPlayer(PlayerId player) const

--- a/src/rwe/GameScene.h
+++ b/src/rwe/GameScene.h
@@ -322,7 +322,7 @@ namespace rwe
 
         std::optional<UnitId> spawnUnit(const std::string& unitType, PlayerId owner, const SimVector& position, std::optional<const std::reference_wrapper<SimAngle>> rotation);
 
-        void spawnCompletedUnit(const std::string& unitType, PlayerId owner, const SimVector& position);
+        std::optional<std::reference_wrapper<Unit>> spawnCompletedUnit(const std::string& unitType, PlayerId owner, const SimVector& position);
 
         void setCameraPosition(const Vector3f& newPosition);
 
@@ -453,6 +453,8 @@ namespace rwe
         std::optional<std::reference_wrapper<Unit>> tryGetUnit(UnitId id);
 
         std::optional<std::reference_wrapper<const Unit>> tryGetUnit(UnitId id) const;
+
+        GamePlayerInfo& getPlayer(PlayerId player);
 
         const GamePlayerInfo& getPlayer(PlayerId player) const;
 

--- a/src/rwe/LoadingScene.cpp
+++ b/src/rwe/LoadingScene.cpp
@@ -239,7 +239,7 @@ namespace rwe
             if (params)
             {
                 auto playerType = std::visit(IsComputerVisitor(), params->controller) ? GamePlayerType::Computer : GamePlayerType::Human;
-                GamePlayerInfo gpi{params->name, playerType, params->color, GamePlayerStatus::Alive, params->side, params->metal, params->metal, params->energy, params->energy};
+                GamePlayerInfo gpi{params->name, playerType, params->color, GamePlayerStatus::Alive, params->side, params->metal, params->energy};
                 auto playerId = simulation.addPlayer(gpi);
                 gamePlayers[i] = playerId;
                 playerCommandService->registerPlayer(playerId);
@@ -352,7 +352,12 @@ namespace rwe
             }
 
             const auto& sideData = getSideData(player->side);
-            gameScene->spawnCompletedUnit(sideData.commander, *gamePlayers[i], worldStartPos);
+            std::optional<std::reference_wrapper<Unit>> commander = gameScene->spawnCompletedUnit(sideData.commander, *gamePlayers[i], worldStartPos);
+            if (commander)
+            {
+                commander->get().energyStorage += Energy(player->energy);
+                commander->get().metalStorage += Metal(player->metal);
+            }
         }
 
         if (!humanStartPos)

--- a/src/rwe/UnitFactory.cpp
+++ b/src/rwe/UnitFactory.cpp
@@ -187,6 +187,9 @@ namespace rwe
 
         unit.extractsMetal = fbi.extractsMetal;
 
+        unit.energyStorage = fbi.energyStorage;
+        unit.metalStorage = fbi.metalStorage;
+
         unit.hideDamage = fbi.hideDamage;
         unit.showPlayerName = fbi.showPlayerName;
 

--- a/src/rwe/io/fbi/UnitFbi.h
+++ b/src/rwe/io/fbi/UnitFbi.h
@@ -69,6 +69,9 @@ namespace rwe
         Metal makesMetal;
         Metal extractsMetal;
 
+        Energy energyStorage;
+        Metal metalStorage;
+
         bool hideDamage;
         bool showPlayerName;
 

--- a/src/rwe/io/fbi/io.cpp
+++ b/src/rwe/io/fbi/io.cpp
@@ -75,6 +75,8 @@ namespace rwe
         tdf.readOrDefault("EnergyUse", u.energyUse);
         tdf.readOrDefault("MetalUse", u.metalUse);
         tdf.readOrDefault("ExtractsMetal", u.extractsMetal);
+        tdf.readOrDefault("EnergyStorage", u.energyStorage);
+        tdf.readOrDefault("MetalStorage", u.metalStorage);
 
         tdf.readOrDefault("MakesMetal", u.makesMetal);
 

--- a/src/rwe/sim/GameSimulation.h
+++ b/src/rwe/sim/GameSimulation.h
@@ -39,10 +39,10 @@ namespace rwe
         std::string side;
 
         Metal metal;
-        Metal maxMetal;
-
         Energy energy;
-        Energy maxEnergy;
+
+        Metal maxMetal{0};
+        Energy maxEnergy{0};
 
         bool metalStalled{false};
         bool energyStalled{false};

--- a/src/rwe/sim/SimScalar.cpp
+++ b/src/rwe/sim/SimScalar.cpp
@@ -1,5 +1,6 @@
 #include "SimScalar.h"
 
+#include <algorithm>
 #include <cmath>
 
 namespace rwe

--- a/src/rwe/sim/Unit.h
+++ b/src/rwe/sim/Unit.h
@@ -257,6 +257,9 @@ namespace rwe
         Energy energyMake;
         Metal metalMake;
 
+        Energy energyStorage;
+        Metal metalStorage;
+
         bool activated{false};
         bool isSufficientlyPowered{false};
 


### PR DESCRIPTION
Units with metal and energy storage now adds it to the players storage. The amount is recalculated once per second together with the other resource updates. The energy and metal storage values set in the lobby is added to the commander's values (I quickly checked and if you make the commander in TA have energy/metal storage, that value is added to, and not overridden by what you set in the lobby). It looks like this might be how TA handles it, since if you play with "continues" for commander death and the commander dies, the player loses that storage. 



I also had to add a include for `<algorithm>` in `SimScalar.cpp` for it to find `std::max`. Not sure why this hasn't been a problem for everyone else? I'm using VS2019 to build if that makes a difference.

![image](https://user-images.githubusercontent.com/14198435/117568900-38069980-b0c3-11eb-8b89-d60db66f475a.png)
