### PR TITLE
Reduce most warnings, remove some unsigned types

### DIFF
--- a/libs/png++-0.2.9/png++/info.hpp
+++ b/libs/png++-0.2.9/png++/info.hpp
@@ -132,7 +132,7 @@ namespace png
 #ifdef PNG_tRNS_SUPPORTED
                     png_set_tRNS(m_png, m_info,
                                  const_cast< byte* >(& m_tRNS[0]),
-                                 m_tRNS.size(),
+                                 static_cast<int>(m_tRNS.size()),
                                  NULL);
 #else
                     throw error("attempted to write tRNS chunk; recompile with PNG_tRNS_SUPPORTED");

--- a/src/cob_test.cpp
+++ b/src/cob_test.cpp
@@ -185,7 +185,7 @@ private:
 
         auto count = it - begin;
 
-        return std::pair<unsigned int, uint32_t>(count, *it++);
+        return std::pair<unsigned int, uint32_t>(static_cast<unsigned int>(count), *it++);
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -296,7 +296,7 @@ namespace rwe
 
         sdlContext->showCursor(SDL_DISABLE);
 
-        SceneManager sceneManager(sdlContext, window.get(), &graphics, &timeService, &imGuiContext, &cursor, &globalConfig, UiRenderService(&graphics, &shaders, UiCamera(viewport.width(), viewport.height())));
+        SceneManager sceneManager(sdlContext, window.get(), &graphics, &timeService, &imGuiContext, &cursor, &globalConfig, UiRenderService(&graphics, &shaders, UiCamera(static_cast<float>(viewport.width()), static_cast<float>(viewport.height()))));
 
         logger.info("Loading side data");
         auto sideDataBytes = vfs.readFile("gamedata/SIDEDATA.TDF");
@@ -348,8 +348,8 @@ namespace rwe
             auto scene = std::make_unique<MainMenuScene>(
                 sceneContext,
                 &allSoundTdf,
-                viewport.width(),
-                viewport.height());
+                static_cast<float>(viewport.width()),
+                static_cast<float>(viewport.height()));
             sceneManager.setNextScene(std::move(scene));
         }
 

--- a/src/rwe/AudioService.cpp
+++ b/src/rwe/AudioService.cpp
@@ -41,7 +41,7 @@ namespace rwe
             return std::nullopt;
         }
 
-        auto rwOps = sdlContext->rwFromConstMem(bytes->data(), bytes->size());
+        auto rwOps = sdlContext->rwFromConstMem(bytes->data(), static_cast<int>(bytes->size()));
         std::shared_ptr<Mix_Chunk> sound(sdlMixerContext->loadWavRw(rwOps.get()));
         sdlMixerContext->volumeChunk(sound.get(), MIX_MAX_VOLUME / 4);
         soundBank[soundName] = sound;

--- a/src/rwe/BoxTreeSplit.cpp
+++ b/src/rwe/BoxTreeSplit.cpp
@@ -2,7 +2,7 @@
 
 namespace rwe
 {
-    Size::Size(std::size_t width, std::size_t height) : width(width), height(height)
+    Size::Size(int width, int height) : width(width), height(height)
     {
     }
 }

--- a/src/rwe/BoxTreeSplit.h
+++ b/src/rwe/BoxTreeSplit.h
@@ -11,16 +11,16 @@ namespace rwe
     template <typename T>
     struct BoxPackInfoEntry
     {
-        unsigned int x;
-        unsigned int y;
+        int x;
+        int y;
         T value;
     };
 
     template <typename T>
     struct BoxPackInfo
     {
-        unsigned int width;
-        unsigned int height;
+        int width;
+        int height;
 
         std::vector<BoxPackInfoEntry<T>> entries;
     };
@@ -40,8 +40,8 @@ namespace rwe
     template <typename T>
     struct BoxTreeNode
     {
-        unsigned int width;
-        unsigned int height;
+        int width;
+        int height;
 
         using Union = std::variant<BoxTreeSplit<T>, BoxTreeLeaf<T>>;
 
@@ -52,13 +52,13 @@ namespace rwe
             std::unique_ptr<BoxTreeNode>&& left,
             std::unique_ptr<BoxTreeNode>&& right);
 
-        BoxTreeNode(unsigned int width, unsigned int height);
+        BoxTreeNode(int width, int height);
 
-        BoxTreeNode(unsigned int width, unsigned int height, const T& value);
+        BoxTreeNode(int width, int height, const T& value);
 
-        BoxTreeNode(unsigned int width, unsigned int height, T&& value);
+        BoxTreeNode(int width, int height, T&& value);
 
-        std::optional<BoxTreeNode<T>*> findNode(unsigned int itemWidth, unsigned int itemHeight);
+        std::optional<BoxTreeNode<T>*> findNode(int itemWidth, int itemHeight);
 
         std::vector<BoxPackInfoEntry<T>> walk();
     };
@@ -97,19 +97,19 @@ namespace rwe
     {
         std::unique_ptr<BoxTreeNode<T>> root;
 
-        BoxTree(unsigned int width, unsigned int height, const T& value)
+        BoxTree(int width, int height, const T& value)
             : root(std::make_unique<BoxTreeNode<T>>(width, height, value))
         {
         }
 
-        BoxTree(unsigned int width, unsigned int height, T&& value)
+        BoxTree(int width, int height, T&& value)
             : root(std::make_unique<BoxTreeNode<T>>(width, height, std::move(value)))
         {
         }
 
-        BoxTreeNode<T>* findOrCreateNode(unsigned int itemWidth, unsigned int itemHeight);
+        BoxTreeNode<T>* findOrCreateNode(int itemWidth, int itemHeight);
 
-        void insert(unsigned int itemWidth, unsigned int itemHeight, const T& item);
+        void insert(int itemWidth, int itemHeight, const T& item);
     };
 
     enum class GrowDirection
@@ -119,7 +119,7 @@ namespace rwe
     };
 
     template <typename T>
-    BoxTreeNode<T>* BoxTree<T>::findOrCreateNode(unsigned int itemWidth, unsigned int itemHeight)
+    BoxTreeNode<T>* BoxTree<T>::findOrCreateNode(int itemWidth, int itemHeight)
     {
         // find a leaf node big enough to fit the box
         auto node = root->findNode(itemWidth, itemHeight);
@@ -165,7 +165,7 @@ namespace rwe
     }
 
     template <typename T>
-    void BoxTree<T>::insert(unsigned int itemWidth, unsigned int itemHeight, const T& item)
+    void BoxTree<T>::insert(int itemWidth, int itemHeight, const T& item)
     {
         auto node = findOrCreateNode(itemWidth, itemHeight);
 
@@ -211,25 +211,25 @@ namespace rwe
     }
 
     template <typename T>
-    BoxTreeNode<T>::BoxTreeNode(unsigned int width, unsigned int height)
+    BoxTreeNode<T>::BoxTreeNode(int width, int height)
         : width(width), height(height), value(BoxTreeLeaf<T>())
     {
     }
 
     template <typename T>
-    BoxTreeNode<T>::BoxTreeNode(unsigned int width, unsigned int height, const T& value)
+    BoxTreeNode<T>::BoxTreeNode(int width, int height, const T& value)
         : width(width), height(height), value(BoxTreeLeaf<T>(value))
     {
     }
 
     template <typename T>
-    BoxTreeNode<T>::BoxTreeNode(unsigned int width, unsigned int height, T&& value)
+    BoxTreeNode<T>::BoxTreeNode(int width, int height, T&& value)
         : width(width), height(height), value(BoxTreeLeaf<T>(std::move(value)))
     {
     }
 
     template <typename T>
-    std::optional<BoxTreeNode<T>*> BoxTreeNode<T>::findNode(unsigned int itemWidth, unsigned int itemHeight)
+    std::optional<BoxTreeNode<T>*> BoxTreeNode<T>::findNode(int itemWidth, int itemHeight)
     {
         if (itemWidth > width || itemHeight > height)
         {
@@ -297,11 +297,11 @@ namespace rwe
 
     struct Size
     {
-        std::size_t width;
-        std::size_t height;
+        int width;
+        int height;
 
         Size() = default;
-        Size(std::size_t width, std::size_t height);
+        Size(int width, int height);
     };
 
     template <typename T>

--- a/src/rwe/CursorService.cpp
+++ b/src/rwe/CursorService.cpp
@@ -42,6 +42,6 @@ namespace rwe
 
         auto frameIndex = (timeInMillis / millisPerFrame) % frames.size();
 
-        renderer.drawSprite(x, y, *(frames[frameIndex]));
+        renderer.drawSprite(static_cast<float>(x), static_cast<float>(y), *(frames[frameIndex]));
     }
 }

--- a/src/rwe/GameHash_util.h
+++ b/src/rwe/GameHash_util.h
@@ -95,7 +95,7 @@ namespace rwe
     template <typename... Ts>
     GameHash computeHashOf(const std::variant<Ts...>& v)
     {
-        return GameHash(v.index())
+        return GameHash(static_cast<uint32_t>(v.index()))
             + match(v, [](const auto& x) { return computeHashOf(x); });
     }
 

--- a/src/rwe/GameNetworkService.cpp
+++ b/src/rwe/GameNetworkService.cpp
@@ -210,7 +210,7 @@ namespace rwe
         {
             throw std::runtime_error("Message to be sent was bigger than buffer size");
         }
-        if (!message.SerializeToArray(sendBuffer.data(), sendBuffer.size()))
+        if (!message.SerializeToArray(sendBuffer.data(), static_cast<int>(sendBuffer.size())))
         {
             throw std::runtime_error("Failed to serialize message to buffer");
         }
@@ -220,14 +220,14 @@ namespace rwe
 
         socket.send_to(boost::asio::buffer(sendBuffer.data(), messageSize + 4), endpoint.endpoint);
 
-        auto nextSequenceNumber = SequenceNumber(endpoint.nextCommandToSend.value + (endpoint.sendBuffer.size()));
+        auto nextSequenceNumber = SequenceNumber(endpoint.nextCommandToSend.value + static_cast<unsigned int>(endpoint.sendBuffer.size()));
         if (endpoint.sendTimes.empty() || endpoint.sendTimes.back().first < nextSequenceNumber)
         {
             endpoint.sendTimes.emplace_back(nextSequenceNumber, sendTime);
         }
     }
 
-    void GameNetworkService::receive(const boost::system::error_code& error, std::size_t receivedBytes)
+    void GameNetworkService::receive(const boost::system::error_code& error, int receivedBytes)
     {
         if (error)
         {
@@ -313,7 +313,7 @@ namespace rwe
             auto ackDelay = std::chrono::milliseconds(message.ack_delay());
             roundTripTime = roundTripTime > ackDelay ? roundTripTime - ackDelay : std::chrono::milliseconds(0);
             auto rttMillis = std::chrono::duration_cast<std::chrono::milliseconds>(roundTripTime).count();
-            endpoint.averageRoundTripTime = ema(rttMillis, endpoint.averageRoundTripTime, 0.1f);
+            endpoint.averageRoundTripTime = ema(static_cast<float>(rttMillis), endpoint.averageRoundTripTime, 0.1f);
             spdlog::get("rwe")->debug("Average RTT: {0}ms", endpoint.averageRoundTripTime);
         }
 
@@ -346,7 +346,7 @@ namespace rwe
         }
 
         GameTime newNextHashToSend(message.next_game_hash_to_receive());
-        if (newNextHashToSend > endpoint.nextHashToSend + GameTime(endpoint.hashSendBuffer.size()))
+        if (newNextHashToSend > endpoint.nextHashToSend + GameTime(static_cast<unsigned int>(endpoint.hashSendBuffer.size())))
         {
             spdlog::get("rwe")->error(
                 "Remote acked up to {0}, but we are at {1} and hash buffer contains {2} elements",

--- a/src/rwe/GameNetworkService.h
+++ b/src/rwe/GameNetworkService.h
@@ -132,6 +132,6 @@ namespace rwe
 
         void send(EndpointInfo& endpoint);
 
-        void receive(const boost::system::error_code& error, std::size_t receivedBytes);
+        void receive(const boost::system::error_code& error, int receivedBytes);
     };
 }

--- a/src/rwe/Index.h
+++ b/src/rwe/Index.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <cstddef>
 
 namespace rwe

--- a/src/rwe/LoadingNetworkService.cpp
+++ b/src/rwe/LoadingNetworkService.cpp
@@ -75,7 +75,7 @@ namespace rwe
         }
     }
 
-    void LoadingNetworkService::onReceive(const boost::system::error_code& error, std::size_t bytesTransferred)
+    void LoadingNetworkService::onReceive(const boost::system::error_code& error, int bytesTransferred)
     {
         if (error)
         {
@@ -110,7 +110,7 @@ namespace rwe
         }
 
         proto::NetworkMessage message;
-        message.ParseFromArray(receiveBuffer.data(), bytesTransferred - 4);
+        message.ParseFromArray(receiveBuffer.data(), static_cast<int>(bytesTransferred - 4));
 
         if (!message.has_loading_status())
         {
@@ -163,7 +163,7 @@ namespace rwe
         {
             throw std::runtime_error("Message to be sent was bigger than buffer size");
         }
-        if (!outerMessage.SerializeToArray(sendBuffer.data(), sendBuffer.size()))
+        if (!outerMessage.SerializeToArray(sendBuffer.data(), static_cast<int>(sendBuffer.size())))
         {
             throw std::runtime_error("Failed to serialize message to buffer");
         }

--- a/src/rwe/LoadingNetworkService.h
+++ b/src/rwe/LoadingNetworkService.h
@@ -68,7 +68,7 @@ namespace rwe
     private:
         void run(const std::string& port);
 
-        void onReceive(const boost::system::error_code& error, std::size_t bytesTransferred);
+        void onReceive(const boost::system::error_code& error, int bytesTransferred);
 
         void notifyStatus();
 

--- a/src/rwe/LoadingScene.h
+++ b/src/rwe/LoadingScene.h
@@ -119,7 +119,7 @@ namespace rwe
         void render() override;
 
     private:
-        static unsigned int computeMidpointHeight(const Grid<unsigned char>& heightmap, std::size_t x, std::size_t y);
+        static int computeMidpointHeight(const Grid<unsigned char>& heightmap, int x, int y);
 
         std::unique_ptr<GameScene> createGameScene(const std::string& mapName, unsigned int schemaIndex);
 
@@ -144,7 +144,7 @@ namespace rwe
 
         MapFeature createFeature(const SimVector& pos, const FeatureDefinition& definition);
 
-        SimVector computeFeaturePosition(const MapTerrain& terrain, const FeatureDefinition& featureDefinition, std::size_t x, std::size_t y) const;
+        SimVector computeFeaturePosition(const MapTerrain& terrain, const FeatureDefinition& featureDefinition, int x, int y) const;
 
         const SideData& getSideData(const std::string& side) const;
 

--- a/src/rwe/MainMenuScene.cpp
+++ b/src/rwe/MainMenuScene.cpp
@@ -603,7 +603,7 @@ namespace rwe
     {
         auto& player = model.players[playerIndex];
         auto currentColor = player.colorIndex.getValue();
-        for (unsigned int i = 1; i < 10; ++i)
+        for (int i = 1; i < 10; ++i)
         {
             auto newColor = PlayerColorIndex((currentColor.value + i) % 10);
             if (!model.isColorInUse(newColor))
@@ -618,7 +618,7 @@ namespace rwe
     {
         auto& player = model.players[playerIndex];
         auto currentColor = player.colorIndex.getValue();
-        for (unsigned int i = 9; i >= 1; --i)
+        for (int i = 9; i >= 1; --i)
         {
             auto newColor = PlayerColorIndex((currentColor.value + i) % 10);
             if (!model.isColorInUse(newColor))
@@ -737,17 +737,17 @@ namespace rwe
 
     void MainMenuScene::attachPlayerSelectionComponents(const std::string& guiName, UiPanel& panel)
     {
-        unsigned int tableStart = 78;
-        unsigned int rowHeight = 20;
+        int tableStart = 78;
+        int rowHeight = 20;
 
         for (int i = 0; i < 10; ++i)
         {
-            unsigned int rowStart = tableStart + (i * rowHeight);
+            int rowStart = tableStart + (i * rowHeight);
 
             {
                 // player name button
-                unsigned int width = 112;
-                unsigned int height = 20;
+                int width = 112;
+                int height = 20;
 
                 auto b = uiFactory.createBasicButton(45, rowStart, width, height, guiName, "skirmname", "Player");
                 b->setName("PLAYER" + std::to_string(i));
@@ -781,15 +781,15 @@ namespace rwe
 
     void MainMenuScene::attachDetailedPlayerSelectionComponents(const std::string& guiName, UiPanel& panel, int i)
     {
-        unsigned int tableStart = 78;
-        unsigned int rowHeight = 20;
+        int tableStart = 78;
+        int rowHeight = 20;
 
-        unsigned int rowStart = tableStart + (i * rowHeight);
+        int rowStart = tableStart + (i * rowHeight);
 
         {
             // side button
-            unsigned int width = 44;
-            unsigned int height = 20;
+            int width = 44;
+            int height = 20;
 
             auto b = uiFactory.createStagedButton(163, rowStart, width, height, guiName, "SIDEx", std::vector<std::string>(2), 2);
             b->setName("PLAYER" + std::to_string(i) + "_side");
@@ -812,15 +812,15 @@ namespace rwe
 
         {
             // color
-            unsigned int width = 19;
-            unsigned int height = 19;
+            int width = 19;
+            int height = 19;
 
             auto graphics = sceneContext.textureService->getGafEntry("anims/LOGOS.GAF", "32xlogos");
             auto newSprites = std::make_shared<SpriteSeries>();
             newSprites->sprites.reserve(graphics->sprites.size());
 
             std::transform(graphics->sprites.begin(), graphics->sprites.end(), std::back_inserter(newSprites->sprites), [width, height](const auto& sprite) {
-                auto bounds = Rectangle2f::fromTopLeft(0.0f, 0.0f, width, height);
+                auto bounds = Rectangle2f::fromTopLeft(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height));
                 return std::make_shared<Sprite>(bounds, sprite->texture, sprite->mesh);
             });
 
@@ -838,8 +838,8 @@ namespace rwe
 
         {
             // ally
-            unsigned int width = 38;
-            unsigned int height = 20;
+            int width = 38;
+            int height = 20;
 
             auto graphics = sceneContext.textureService->getGuiTexture(guiName, "TEAMICONSx");
             if (!graphics)
@@ -896,8 +896,8 @@ namespace rwe
 
         {
             // metal
-            unsigned int width = 46;
-            unsigned int height = 20;
+            int width = 46;
+            int height = 20;
 
             auto b = uiFactory.createButton(286, rowStart, width, height, guiName, "skirmmet", "");
             b->setName("PLAYER" + std::to_string(i) + "_metal");
@@ -913,8 +913,8 @@ namespace rwe
 
         {
             // energy
-            unsigned int width = 46;
-            unsigned int height = 20;
+            int width = 46;
+            int height = 20;
 
             auto b = uiFactory.createButton(337, rowStart, width, height, guiName, "skirmmet", "");
             b->setName("PLAYER" + std::to_string(i) + "_energy");

--- a/src/rwe/MapTerrainGraphics.cpp
+++ b/src/rwe/MapTerrainGraphics.cpp
@@ -34,19 +34,19 @@ namespace rwe
         auto widthInWorldUnits = getWidthInWorldUnits();
         auto heightInWorldUnits = getHeightInWorldUnits();
 
-        auto worldX = (SimScalar(x) * TileWidthInWorldUnits) - (widthInWorldUnits / 2_ss);
-        auto worldY = (SimScalar(y) * TileHeightInWorldUnits) - (heightInWorldUnits / 2_ss);
+        auto worldX = (simScalarFromInt(x) * TileWidthInWorldUnits) - (widthInWorldUnits / 2_ss);
+        auto worldY = (simScalarFromInt(y) * TileHeightInWorldUnits) - (heightInWorldUnits / 2_ss);
 
         return SimVector(worldX, 0_ss, worldY);
     }
 
     SimScalar MapTerrainGraphics::getWidthInWorldUnits() const
     {
-        return SimScalar(tiles.getWidth()) * TileWidthInWorldUnits;
+        return simScalarFromInt(tiles.getWidth()) * TileWidthInWorldUnits;
     }
 
     SimScalar MapTerrainGraphics::getHeightInWorldUnits() const
     {
-        return SimScalar(tiles.getHeight()) * TileHeightInWorldUnits;
+        return simScalarFromInt(tiles.getHeight()) * TileHeightInWorldUnits;
     }
 }

--- a/src/rwe/PlayerColorIndex.cpp
+++ b/src/rwe/PlayerColorIndex.cpp
@@ -3,9 +3,9 @@
 
 namespace rwe
 {
-    PlayerColorIndex::PlayerColorIndex(unsigned int _value) : OpaqueId(_value)
+    PlayerColorIndex::PlayerColorIndex(int _value) : OpaqueId(_value)
     {
-        if (_value >= 10u)
+        if (_value >= 10 || _value < 0)
         {
             throw std::logic_error("Player color index out of range");
         }

--- a/src/rwe/PlayerColorIndex.h
+++ b/src/rwe/PlayerColorIndex.h
@@ -5,8 +5,8 @@
 namespace rwe
 {
     struct PlayerColorIndexTag;
-    struct PlayerColorIndex : public OpaqueId<unsigned int, PlayerColorIndexTag>
+    struct PlayerColorIndex : public OpaqueId<int, PlayerColorIndexTag>
     {
-        explicit PlayerColorIndex(unsigned int value);
+        explicit PlayerColorIndex(int value);
     };
 }

--- a/src/rwe/PlayerCommandService.cpp
+++ b/src/rwe/PlayerCommandService.cpp
@@ -53,7 +53,7 @@ namespace rwe
     {
         std::scoped_lock<std::mutex> lock(mutex);
 
-        return commandBuffers.at(player).size();
+        return static_cast<unsigned int>(commandBuffers.at(player).size());
     }
 
     bool PlayerCommandService::checkHashes()

--- a/src/rwe/RenderService.cpp
+++ b/src/rwe/RenderService.cpp
@@ -389,7 +389,7 @@ namespace rwe
                     const auto& shader = shaders->basicTexture;
                     graphics->bindShader(shader.handle.get());
                     const auto spriteSeries = meshDatabase.getSpriteSeries(s.gaf, s.anim).value();
-                    const auto& sprite = *spriteSeries->sprites[getFrameIndex(currentTime, spriteSeries->sprites.size())];
+                    const auto& sprite = *spriteSeries->sprites[getFrameIndex(currentTime, static_cast<unsigned int>(spriteSeries->sprites.size()))];
                     auto modelMatrix = Matrix4f::translation(snappedPosition) * conversionMatrix * sprite.getTransform();
                     graphics->bindTexture(sprite.texture.get());
                     graphics->setUniformMatrix(shader.mvpMatrix, camera.getViewProjectionMatrix() * modelMatrix);
@@ -452,12 +452,12 @@ namespace rwe
         {
             auto spriteSeries = meshDatabase.getSpriteSeries(exp.explosionGaf, exp.explosionAnim).value();
 
-            if (!exp.isStarted(currentTime) || exp.isFinished(currentTime, spriteSeries->sprites.size()))
+            if (!exp.isStarted(currentTime) || exp.isFinished(currentTime, static_cast<int>(spriteSeries->sprites.size())))
             {
                 continue;
             }
 
-            auto frameIndex = exp.getFrameIndex(currentTime, spriteSeries->sprites.size());
+            auto frameIndex = exp.getFrameIndex(currentTime, static_cast<int>(spriteSeries->sprites.size()));
             const auto& sprite = *spriteSeries->sprites[frameIndex];
 
             float alpha = exp.translucent ? 0.5f : 1.0f;
@@ -610,7 +610,7 @@ namespace rwe
         {
             auto& exp = *it;
             const auto anim = meshDatabase.getSpriteSeries(exp.explosionGaf, exp.explosionAnim).value();
-            if (exp.isFinished(currentTime, anim->sprites.size()))
+            if (exp.isFinished(currentTime, static_cast<int>(anim->sprites.size())))
             {
                 exp = std::move(*--end);
                 continue;

--- a/src/rwe/SideData.cpp
+++ b/src/rwe/SideData.cpp
@@ -2,7 +2,7 @@
 
 namespace rwe
 {
-    SideDataRect::SideDataRect(unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2)
+    SideDataRect::SideDataRect(int x1, int y1, int x2, int y2)
         : x1(x1), y1(y1), x2(x2), y2(y2)
     {
     }
@@ -19,8 +19,8 @@ namespace rwe
 
     DiscreteRect SideDataRect::toDiscreteRect() const
     {
-        unsigned int minX;
-        unsigned int maxX;
+        int minX;
+        int maxX;
         if (x1 < x2)
         {
             minX = x1;
@@ -32,8 +32,8 @@ namespace rwe
             maxX = x1;
         }
 
-        unsigned int minY;
-        unsigned int maxY;
+        int minY;
+        int maxY;
         if (y1 < y2)
         {
             minY = y1;

--- a/src/rwe/SideData.h
+++ b/src/rwe/SideData.h
@@ -8,13 +8,13 @@ namespace rwe
 {
     struct SideDataRect
     {
-        unsigned int x1;
-        unsigned int y1;
-        unsigned int x2;
-        unsigned int y2;
+        int x1;
+        int y1;
+        int x2;
+        int y2;
 
         SideDataRect() = default;
-        SideDataRect(unsigned int x1, unsigned int y1, unsigned int x2, unsigned int y2);
+        SideDataRect(int x1, int y1, int x2, int y2);
 
         bool operator==(const SideDataRect& rhs) const;
 
@@ -32,8 +32,8 @@ namespace rwe
 
         std::string font;
         std::string fontGui;
-        unsigned int energyColor;
-        unsigned int metalColor;
+        int energyColor;
+        int metalColor;
 
         SideDataRect logo;
         SideDataRect energyBar;

--- a/src/rwe/TextureService.cpp
+++ b/src/rwe/TextureService.cpp
@@ -62,10 +62,10 @@ namespace rwe
             SharedTextureHandle handle(graphics->createTexture(currentFrameHeader.width, currentFrameHeader.height, buffer));
 
             auto bounds = Rectangle2f::fromTopLeft(
-                -currentFrameHeader.posX,
-                -currentFrameHeader.posY,
-                currentFrameHeader.width,
-                currentFrameHeader.height);
+                static_cast<float>(-currentFrameHeader.posX),
+                static_cast<float>(-currentFrameHeader.posY),
+                static_cast<float>(currentFrameHeader.width),
+                static_cast<float>(currentFrameHeader.height));
 
             auto region = Rectangle2f::fromTopLeft(0.0f, 0.0f, 1.0f, 1.0f);
 
@@ -177,14 +177,14 @@ namespace rwe
         return defaultSpriteSeries->sprites[0]->texture;
     }
 
-    std::shared_ptr<Sprite> TextureService::getBitmapRegion(const std::string& bitmapName, int x, int y, int width, int height)
+    std::shared_ptr<Sprite> TextureService::getBitmapRegion(const std::string& bitmapName, float x, float y, float width, float height)
     {
         auto bitmap = getBitmapInternal(bitmapName);
         auto region = Rectangle2f::fromTopLeft(
-            static_cast<float>(x) / static_cast<float>(bitmap.width),
-            static_cast<float>(y) / static_cast<float>(bitmap.height),
-            static_cast<float>(width) / static_cast<float>(bitmap.width),
-            static_cast<float>(height) / static_cast<float>(bitmap.height));
+            x / static_cast<float>(bitmap.width),
+            y / static_cast<float>(bitmap.height),
+            width / static_cast<float>(bitmap.width),
+            height / static_cast<float>(bitmap.height));
         auto bounds = Rectangle2f::fromTopLeft(x, y, width, height);
         return std::make_shared<Sprite>(graphics->createSprite(bounds, region, bitmap.handle));
     }
@@ -251,7 +251,7 @@ namespace rwe
 
         SharedTextureHandle texture(graphics->createTexture(minimap.width, minimap.height, rgbMinimap));
         auto sprite = graphics->createSprite(
-            Rectangle2f::fromTopLeft(0.0f, 0.0f, minimap.width, minimap.height),
+            Rectangle2f::fromTopLeft(0.0f, 0.0f, static_cast<float>(minimap.width), static_cast<float>(minimap.height)),
             Rectangle2f::fromTopLeft(0.0f, 0.0f, 1.0f, 1.0f),
             texture);
         auto spritePtr = std::make_shared<Sprite>(std::move(sprite));
@@ -303,7 +303,7 @@ namespace rwe
 
             SharedTextureHandle texture(graphics->createTexture(width, fnt.glyphHeight(), rgbGlyph));
             auto sprite = std::make_shared<Sprite>(graphics->createSprite(
-                Rectangle2f::fromTopLeft(0.0f, 0.0f, width, fnt.glyphHeight()),
+                Rectangle2f::fromTopLeft(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(fnt.glyphHeight())),
                 Rectangle2f::fromTopLeft(0.0f, 0.0f, 1.0f, 1.0f),
                 texture));
 

--- a/src/rwe/TextureService.h
+++ b/src/rwe/TextureService.h
@@ -41,7 +41,7 @@ namespace rwe
         std::shared_ptr<SpriteSeries> getGafEntry(const std::string& gafName, const std::string& entryName);
         std::optional<std::shared_ptr<SpriteSeries>> getGuiTexture(const std::string& guiName, const std::string& graphicName);
         SharedTextureHandle getBitmap(const std::string& bitmapName);
-        std::shared_ptr<Sprite> getBitmapRegion(const std::string& bitmapName, int x, int y, int width, int height);
+        std::shared_ptr<Sprite> getBitmapRegion(const std::string& bitmapName, float x, float y, float width, float height);
         SharedTextureHandle getDefaultTexture();
         std::shared_ptr<SpriteSeries> getDefaultSpriteSeries();
         std::shared_ptr<Sprite> getDefaultSprite();

--- a/src/rwe/UiRenderService.cpp
+++ b/src/rwe/UiRenderService.cpp
@@ -44,6 +44,11 @@ namespace rwe
         drawSprite(x - sprite.bounds.left(), y - sprite.bounds.top(), sprite);
     }
 
+    void UiRenderService::drawSpriteAbs(int x, int y, int width, int height, const Sprite& sprite)
+    {
+        drawSpriteAbs(static_cast<float>(x), static_cast<float>(y), static_cast<float>(width), static_cast<float>(height), sprite);
+    }
+
     void UiRenderService::drawSpriteAbs(float x, float y, float width, float height, const Sprite& sprite)
     {
         auto matrix = Matrix4f::translation(Vector3f(x, y, 0.0f))
@@ -61,12 +66,12 @@ namespace rwe
         drawSpriteAbs(rect.left(), rect.top(), rect.width(), rect.height(), sprite);
     }
 
-    void UiRenderService::drawText(float x, float y, const std::string& text, const SpriteSeries& font)
+    void UiRenderService::drawText(int x, int y, const std::string& text, const SpriteSeries& font, const Color& tint /*= Color(255, 255, 255)*/)
     {
-        drawText(x, y, text, font, Color(255, 255, 255));
+        drawText(static_cast<float>(x), static_cast<float>(y), text, font, tint);
     }
 
-    void UiRenderService::drawText(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint)
+    void UiRenderService::drawText(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint /*= Color(255, 255, 255)*/)
     {
         auto it = utf8Begin(text);
         auto end = utf8End(text);
@@ -127,12 +132,12 @@ namespace rwe
         drawText(std::round(x - halfWidth), y, text, font);
     }
 
-    void UiRenderService::drawTextAlignRight(float x, float y, const std::string& text, const SpriteSeries& font)
+    void UiRenderService::drawTextAlignRight(int x, int y, const std::string& text, const SpriteSeries& font, const Color& tint /*= Color(255, 255, 255)*/)
     {
-        drawTextAlignRight(x, y, text, font, Color(255, 255, 255));
+        drawTextAlignRight(static_cast<float>(x), static_cast<float>(y), text, font, tint);
     }
 
-    void UiRenderService::drawTextAlignRight(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint)
+    void UiRenderService::drawTextAlignRight(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint /*= Color(255, 255, 255)*/)
     {
         auto width = getTextWidth(text, font);
         drawText(x - width, y, text, font, tint);
@@ -260,20 +265,21 @@ namespace rwe
         fillColor(x + borderWidth, y + borderWidth, innerWidth, innerHeight, healthColor);
     }
 
-    void UiRenderService::drawHealthBar2(float x, float y, float width, float height, float percentFull)
+    void UiRenderService::drawHealthBar2(int x, int y, int width, int height, int hitPoints, int maxHitPoints)
     {
-        assert(percentFull >= 0.0f && percentFull <= 1.0f);
-        float healthWidth = width * percentFull;
-        fillColor(x, y, healthWidth, height, Color(83, 223, 79));
-        fillColor(x + healthWidth, y, width - healthWidth, height, Color(171, 23, 0));
+        float ratioFull = static_cast<float>(hitPoints) / static_cast<float>(maxHitPoints);
+        assert(ratioFull >= 0.0f && ratioFull <= 1.0f);
+        float healthWidth = width * ratioFull;
+        fillColor(static_cast<float>(x), static_cast<float>(y), healthWidth, static_cast<float>(height), Color(83, 223, 79));
+        fillColor(x + healthWidth, static_cast<float>(y), width - healthWidth, static_cast<float>(height), Color(171, 23, 0));
     }
 
-    void UiRenderService::drawBoxOutline(float x, float y, float width, float height, Color color)
+    void UiRenderService::drawBoxOutline(int x, int y, int width, int height, Color color, float thickness /*= 1.0f*/)
     {
-        drawBoxOutline(x, y, width, height, color, 1.0f);
+        drawBoxOutline(static_cast<float>(x), static_cast<float>(y), static_cast<float>(width), static_cast<float>(height), color, thickness);
     }
 
-    void UiRenderService::drawBoxOutline(float x, float y, float width, float height, Color color, float thickness)
+    void UiRenderService::drawBoxOutline(float x, float y, float width, float height, Color color, float thickness /*= 1.0f*/)
     {
         assert(width >= 0.0f);
         assert(height >= 0.0f);

--- a/src/rwe/UiRenderService.h
+++ b/src/rwe/UiRenderService.h
@@ -30,12 +30,13 @@ namespace rwe
         /** Draws the sprite, ignoring its internal x and y offset. */
         void drawSpriteAbs(float x, float y, const Sprite& sprite);
 
+        void drawSpriteAbs(  int x,   int y,   int width,   int height, const Sprite& sprite);
         void drawSpriteAbs(float x, float y, float width, float height, const Sprite& sprite);
 
         void drawSpriteAbs(const Rectangle2f& rect, const Sprite& sprite);
 
-        void drawText(float x, float y, const std::string& text, const SpriteSeries& font);
-        void drawText(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint);
+        void drawText(  int x,   int y, const std::string& text, const SpriteSeries& font, const Color& tint = Color(255, 255, 255));
+        void drawText(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint = Color(255, 255, 255));
 
         void drawTextWrapped(Rectangle2f area, const std::string& text, const SpriteSeries& font);
 
@@ -43,8 +44,8 @@ namespace rwe
 
         void drawTextCenteredX(float x, float y, const std::string& text, const SpriteSeries& font);
 
-        void drawTextAlignRight(float x, float y, const std::string& text, const SpriteSeries& font);
-        void drawTextAlignRight(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint);
+        void drawTextAlignRight(  int x,   int y, const std::string& text, const SpriteSeries& font, const Color& tint = Color(255, 255, 255));
+        void drawTextAlignRight(float x, float y, const std::string& text, const SpriteSeries& font, const Color& tint = Color(255, 255, 255));
 
         float getTextWidth(const std::string& text, const SpriteSeries& font);
 
@@ -73,11 +74,10 @@ namespace rwe
 
         void drawHealthBar(float x, float y, float percentFull);
 
-        void drawHealthBar2(float x, float y, float width, float height, float percentFull);
+        void drawHealthBar2(int x, int y, int width, int height, int hitPoints, int maxHitPoints);
 
-        void drawBoxOutline(float x, float y, float width, float height, Color color);
-
-        void drawBoxOutline(float x, float y, float width, float height, Color color, float thickness);
+        void drawBoxOutline(  int x,   int y,   int width,   int height, Color color, float thickness = 1.0f);
+        void drawBoxOutline(float x, float y, float width, float height, Color color, float thickness = 1.0f);
 
         void drawLine(const Vector2f& start, const Vector2f& end);
     };

--- a/src/rwe/UnitFactory.cpp
+++ b/src/rwe/UnitFactory.cpp
@@ -174,7 +174,7 @@ namespace rwe
         // Worker time is per second, assuming 30 ticks per second.
         unit.workerTimePerTick = fbi.workerTime / 30;
 
-        unit.buildDistance = SimScalar(fbi.buildDistance);
+        unit.buildDistance = simScalarFromUInt(fbi.buildDistance);
 
         unit.onOffable = fbi.onOffable;
         unit.activateWhenBuilt = fbi.activateWhenBuilt;
@@ -255,7 +255,7 @@ namespace rwe
         return unit;
     }
 
-    std::optional<std::reference_wrapper<const std::vector<GuiEntry>>> UnitFactory::getBuilderGui(const std::string& unitType, unsigned int page) const
+    std::optional<std::reference_wrapper<const std::vector<GuiEntry>>> UnitFactory::getBuilderGui(const std::string& unitType, int page) const
     {
         const auto& pages = unitDatabase->tryGetBuilderGui(unitType);
         if (!pages)
@@ -273,7 +273,7 @@ namespace rwe
         return unwrappedPages[page];
     }
 
-    unsigned int UnitFactory::getBuildPageCount(const std::string& unitType) const
+    int UnitFactory::getBuildPageCount(const std::string& unitType) const
     {
         const auto& pages = unitDatabase->tryGetBuilderGui(unitType);
         if (!pages)
@@ -281,7 +281,7 @@ namespace rwe
             return 0;
         }
 
-        return pages->get().size();
+        return static_cast<int>(pages->get().size());
     }
 
     Point UnitFactory::getUnitFootprint(const std::string& unitType) const
@@ -350,11 +350,11 @@ namespace rwe
 
         weapon.weaponType = weaponType;
 
-        weapon.weaponDefinition.maxRange = SimScalar(tdf.range);
+        weapon.weaponDefinition.maxRange = simScalarFromUInt(tdf.range);
         weapon.weaponDefinition.reloadTime = SimScalar(tdf.reloadTime);
         weapon.weaponDefinition.tolerance = SimAngle(tdf.tolerance);
         weapon.weaponDefinition.pitchTolerance = SimAngle(tdf.pitchTolerance);
-        weapon.weaponDefinition.velocity = SimScalar(static_cast<float>(tdf.weaponVelocity) / 30.0f);
+        weapon.weaponDefinition.velocity = simScalarFromUInt(tdf.weaponVelocity) / 30.0_ssf;
 
         weapon.weaponDefinition.burst = tdf.burst;
         weapon.weaponDefinition.burstInterval = SimScalar(tdf.burstRate);
@@ -446,7 +446,7 @@ namespace rwe
             weapon.weaponDefinition.damage.insert_or_assign(toUpper(p.first), p.second);
         }
 
-        weapon.weaponDefinition.damageRadius = SimScalar(static_cast<float>(tdf.areaOfEffect) / 2.0f);
+        weapon.weaponDefinition.damageRadius = simScalarFromUInt(tdf.areaOfEffect) * 0.5_ssf;
 
         if (tdf.weaponTimer != 0.0f)
         {
@@ -468,7 +468,7 @@ namespace rwe
             static_cast<float>(color.b) / 255.0f);
     }
 
-    unsigned int colorDistance(const Color& a, const Color& b)
+    int colorDistance(const Color& a, const Color& b)
     {
         auto dr = a.r > b.r ? a.r - b.r : b.r - a.r;
         auto dg = a.g > b.g ? a.g - b.g : b.g - a.g;

--- a/src/rwe/UnitFactory.h
+++ b/src/rwe/UnitFactory.h
@@ -32,10 +32,10 @@ namespace rwe
     public:
         Unit createUnit(const std::string& unitType, PlayerId owner, const SimVector& position, std::optional<const std::reference_wrapper<SimAngle>> rotation);
 
-        std::optional<std::reference_wrapper<const std::vector<GuiEntry>>> getBuilderGui(const std::string& unitType, unsigned int page) const;
+        std::optional<std::reference_wrapper<const std::vector<GuiEntry>>> getBuilderGui(const std::string& unitType, int page) const;
 
         /** If the unit has no build gui, this will be zero. */
-        unsigned int getBuildPageCount(const std::string& unitType) const;
+        int getBuildPageCount(const std::string& unitType) const;
 
         Point getUnitFootprint(const std::string& unitType) const;
 

--- a/src/rwe/VectorMap.h
+++ b/src/rwe/VectorMap.h
@@ -116,7 +116,7 @@ namespace rwe
             }
             else
             {
-                auto id = makeId(Index(vec.size()));
+                auto id = makeId(Index(static_cast<unsigned int>(vec.size())));
                 vec.emplace_back(std::make_pair(id, T(std::forward<Args>(args)...)));
                 return id;
             }

--- a/src/rwe/Viewport.cpp
+++ b/src/rwe/Viewport.cpp
@@ -3,7 +3,7 @@
 
 namespace rwe
 {
-    Viewport::Viewport(int x, int y, unsigned int width, unsigned int height) : _x(x), _y(y), _width(width), _height(height)
+    Viewport::Viewport(int x, int y, int width, int height) : _x(x), _y(y), _width(width), _height(height)
     {
     }
 
@@ -62,12 +62,12 @@ namespace rwe
         return _y;
     }
 
-    unsigned int Viewport::width() const
+    int Viewport::width() const
     {
         return _width;
     }
 
-    unsigned int Viewport::height() const
+    int Viewport::height() const
     {
         return _height;
     }

--- a/src/rwe/Viewport.h
+++ b/src/rwe/Viewport.h
@@ -10,11 +10,11 @@ namespace rwe
     private:
         int _x;
         int _y;
-        unsigned int _width;
-        unsigned int _height;
+        int _width;
+        int _height;
 
     public:
-        Viewport(int x, int y, unsigned int width, unsigned int height);
+        Viewport(int x, int y, int width, int height);
 
         Vector2f toClipSpace(int x, int y) const;
 
@@ -32,9 +32,9 @@ namespace rwe
 
         int y() const;
 
-        unsigned int width() const;
+        int width() const;
 
-        unsigned int height() const;
+        int height() const;
 
         int top() const { return _y; }
         int bottom() const { return _y + static_cast<int>(_height); }

--- a/src/rwe/atlas_util.cpp
+++ b/src/rwe/atlas_util.cpp
@@ -78,7 +78,7 @@ namespace rwe
     };
     struct AtlasItemColor
     {
-        unsigned int colorIndex;
+        int colorIndex;
     };
     using AtlasItem = std::variant<AtlasItemFrame, AtlasItemColor>;
 
@@ -221,7 +221,7 @@ namespace rwe
             frameRefs.emplace_back(AtlasItemFrame{&f});
         }
 
-        for (unsigned int i = 0; i < palette->size(); ++i)
+        for (int i = 0; i < palette->size(); ++i)
         {
             frameRefs.emplace_back(AtlasItemColor{i});
         }

--- a/src/rwe/cob/CobAngularSpeed.h
+++ b/src/rwe/cob/CobAngularSpeed.h
@@ -14,7 +14,7 @@ namespace rwe
 
         SimScalar toSimScalar() const
         {
-            return SimScalar(value);
+            return SimScalar(static_cast<float>(value));
         }
     };
 }

--- a/src/rwe/cob/CobPosition.h
+++ b/src/rwe/cob/CobPosition.h
@@ -27,7 +27,7 @@ namespace rwe
 
         static CobPosition fromWorldDistance(SimScalar d)
         {
-            return CobPosition(d.value * 65536.0f);
+            return CobPosition(static_cast <int32_t>(d.value * 65536.0f));
         }
     };
 }

--- a/src/rwe/geometry/Circle2f.test.cpp
+++ b/src/rwe/geometry/Circle2f.test.cpp
@@ -31,25 +31,25 @@ namespace rwe
         }
 
         rc::prop("works when point is within radius distance on axes", []() {
-            auto x = *rc::gen::inRange(-10000, 10000);
-            auto y = *rc::gen::inRange(-10000, 10000);
-            auto radius = *rc::gen::inRange(0, 10000);
-            auto distance = *rc::gen::inRange(-radius, radius + 1);
-            Circle2f c(radius, Vector2f(x, y));
+            float x = static_cast<float>(*rc::gen::inRange(-10000, 10000));
+            float y = static_cast<float>(*rc::gen::inRange(-10000, 10000));
+            int radius = *rc::gen::inRange(0, 10000);
+            float distance = static_cast<float>(*rc::gen::inRange(-radius, radius + 1));
+            Circle2f c(static_cast<float>(radius), Vector2f(x, y));
             Vector2f px(x + distance, y);
             Vector2f py(x, y + distance);
             RC_ASSERT(c.contains(px));
             RC_ASSERT(c.contains(py));
         });
         rc::prop("works when point is within sqrt(radius) distance on axes", []() {
-            auto x = *rc::gen::inRange(-10000, 10000);
-            auto y = *rc::gen::inRange(-10000, 10000);
+            auto x = static_cast<float>(*rc::gen::inRange(-10000, 10000));
+            auto y = static_cast<float>(*rc::gen::inRange(-10000, 10000));
             auto radius = *rc::gen::inRange(0, 10000);
-            auto dx = *rc::gen::inRange(-radius, radius + 1);
-            auto dy = *rc::gen::inRange(-radius, radius + 1);
+            auto dx = static_cast<float>(*rc::gen::inRange(-radius, radius + 1));
+            auto dy = static_cast<float>(*rc::gen::inRange(-radius, radius + 1));
 
-            const auto scale = std::sin(Pif / 4);
-            Circle2f c(radius, Vector2f(x, y));
+            const auto scale = std::sin(Pif / 4.f);
+            Circle2f c(static_cast<float>(radius), Vector2f(x, y));
             Vector2f p(x + (dx * scale * 0.9f), y + (dy * scale * 0.9f));
             RC_ASSERT(c.contains(p));
         });

--- a/src/rwe/grid/DiscreteRect.h
+++ b/src/rwe/grid/DiscreteRect.h
@@ -13,11 +13,11 @@ namespace rwe
 
         int x;
         int y;
-        unsigned int width;
-        unsigned int height;
+        int width;
+        int height;
 
         DiscreteRect() = default;
-        DiscreteRect(int x, int y, unsigned int width, unsigned int height) : x(x), y(y), width(width), height(height)
+        DiscreteRect(int x, int y, int width, int height) : x(x), y(y), width(width), height(height)
         {
         }
 

--- a/src/rwe/grid/Grid.h
+++ b/src/rwe/grid/Grid.h
@@ -7,15 +7,16 @@
 #include <rwe/grid/DiscreteRect.h>
 #include <stdexcept>
 #include <vector>
+#include <rwe/Index.h>
 
 namespace rwe
 {
     struct GridCoordinates
     {
-        std::size_t x;
-        std::size_t y;
+        int x;
+        int y;
         GridCoordinates() = default;
-        GridCoordinates(size_t x, size_t y) : x(x), y(y)
+        GridCoordinates(int x, int y) : x(x), y(y)
         {
         }
 
@@ -39,21 +40,22 @@ namespace rwe
             return GridRegion(x.first, y.first, x.second - x.first + 1, y.second - y.first + 1);
         }
 
-        std::size_t x;
-        std::size_t y;
-        std::size_t width;
-        std::size_t height;
+        int x;
+        int y;
+        int width;
+        int height;
 
         GridRegion() = default;
-        GridRegion(unsigned int x, unsigned int y, unsigned int width, unsigned int height)
+
+        GridRegion(int x, int y, int width, int height)
             : x(x), y(y), width(width), height(height) {}
 
         template <typename Func>
         void forEach(Func f) const
         {
-            for (std::size_t dy = 0; dy < height; ++dy)
+            for (int dy = 0; dy < height; ++dy)
             {
-                for (std::size_t dx = 0; dx < width; ++dx)
+                for (int dx = 0; dx < width; ++dx)
                 {
                     f(GridCoordinates(x + dx, y + dy));
                 }
@@ -63,9 +65,9 @@ namespace rwe
         template <typename Func>
         void forEach(Func f)
         {
-            for (std::size_t dy = 0; dy < height; ++dy)
+            for (int dy = 0; dy < height; ++dy)
             {
-                for (std::size_t dx = 0; dx < width; ++dx)
+                for (int dx = 0; dx < width; ++dx)
                 {
                     f(GridCoordinates(x + dx, y + dy));
                 }
@@ -75,9 +77,9 @@ namespace rwe
         template <typename Func>
         bool any(Func f) const
         {
-            for (std::size_t dy = 0; dy < height; ++dy)
+            for (int dy = 0; dy < height; ++dy)
             {
-                for (std::size_t dx = 0; dx < width; ++dx)
+                for (int dx = 0; dx < width; ++dx)
                 {
                     if (f(GridCoordinates(x + dx, y + dy)))
                     {
@@ -101,13 +103,13 @@ namespace rwe
     class Grid
     {
     private:
-        std::size_t width;
-        std::size_t height;
+        int width;
+        int height;
         std::vector<T> data;
 
     public:
         template <typename Func>
-        static Grid<T> from(std::size_t width, std::size_t height, Func f)
+        static Grid<T> from(int width, int height, Func f)
         {
             Grid<T> g(width, height);
             g.fill(f);
@@ -116,24 +118,24 @@ namespace rwe
 
         Grid() : width(0), height(0) {}
 
-        Grid(std::size_t width, std::size_t height)
+        Grid(int width, int height)
             : width(width), height(height), data(width * height) {}
 
-        Grid(std::size_t width, std::size_t height, const T& initialValue)
+        Grid(int width, int height, const T& initialValue)
             : width(width), height(height), data(width * height, initialValue) {}
 
-        Grid(std::size_t width, std::size_t height, std::vector<T>&& data)
+        Grid(int width, int height, std::vector<T>&& data)
             : width(width), height(height), data(std::move(data))
         {
             assert(this->data.size() == width * height);
         }
 
-        T& get(std::size_t x, std::size_t y)
+        T& get(int x, int y)
         {
             return data[toIndex(x, y)];
         }
 
-        const T& get(std::size_t x, std::size_t y) const
+        const T& get(int x, int y) const
         {
             return data[toIndex(x, y)];
         }
@@ -148,12 +150,12 @@ namespace rwe
             return data[toIndex(coords)];
         }
 
-        void set(std::size_t x, std::size_t y, const T& value)
+        void set(int x, int y, const T& value)
         {
             data[toIndex(x, y)] = value;
         }
 
-        void set(std::size_t x, std::size_t y, T&& value)
+        void set(int x, int y, T&& value)
         {
             data[toIndex(x, y)] = std::move(value);
         }
@@ -185,24 +187,24 @@ namespace rwe
             return !(rhs == *this);
         }
 
-        std::size_t toIndex(std::size_t x, std::size_t y) const
+        Index toIndex(int x, int y) const
         {
             assert(x < width && y < height);
-            return (y * width) + x;
+            return (static_cast <Index>(y) * width) + x;
         }
 
-        std::size_t toIndex(const GridCoordinates& coords) const
+        Index toIndex(const GridCoordinates& coords) const
         {
             assert(coords.x < width && coords.y < height);
-            return (coords.y * width) + coords.x;
+            return (static_cast <Index>(coords.y) * width) + coords.x;
         }
 
-        std::size_t getWidth() const
+        int getWidth() const
         {
             return width;
         }
 
-        std::size_t getHeight() const
+        int getHeight() const
         {
             return height;
         }
@@ -232,16 +234,16 @@ namespace rwe
             return GridRegion(0, 0, width, height);
         }
 
-        void replace(std::size_t x, std::size_t y, const Grid<T>& replacement)
+        void replace(int x, int y, const Grid<T>& replacement)
         {
             if (x + replacement.getWidth() > getWidth() || y + replacement.getHeight() > getHeight())
             {
                 throw std::logic_error("replacement goes out of bounds");
             }
 
-            for (std::size_t dy = 0; dy < replacement.getHeight(); ++dy)
+            for (int dy = 0; dy < replacement.getHeight(); ++dy)
             {
-                for (std::size_t dx = 0; dx < replacement.getWidth(); ++dx)
+                for (int dx = 0; dx < replacement.getWidth(); ++dx)
                 {
                     set(x + dx, y + dy, replacement.get(dx, dy));
                 }
@@ -269,7 +271,7 @@ namespace rwe
         }
 
         template <typename U, typename BinaryFunc>
-        bool any2(unsigned int x, unsigned int y, const Grid<U>& g, BinaryFunc f) const
+        bool any2(int x, int y, const Grid<U>& g, BinaryFunc f) const
         {
             assert(x + g.getWidth() <= this->width);
             assert(y + g.getHeight() <= this->height);
@@ -285,7 +287,7 @@ namespace rwe
         }
 
         template <typename U, typename BinaryFunc>
-        void forEach2(unsigned int x, unsigned int y, const Grid<U>& g, BinaryFunc f)
+        void forEach2(int x, int y, const Grid<U>& g, BinaryFunc f)
         {
             assert(x + g.getWidth() <= this->width);
             assert(y + g.getHeight() <= this->height);
@@ -327,8 +329,8 @@ namespace rwe
         {
             return rect.x >= 0
                 && rect.y >= 0
-                && static_cast<unsigned int>(rect.x) + rect.width <= width
-                && static_cast<unsigned int>(rect.y) + rect.height <= height;
+                && rect.x + rect.width <= width
+                && rect.y + rect.height <= height;
         }
 
         /**
@@ -357,13 +359,13 @@ namespace rwe
          */
         GridCoordinates clampToCoords(const Point& p) const
         {
-            std::size_t x = (p.x > 0) ? static_cast<std::size_t>(p.x) : 0;
+            int x = (p.x > 0) ? p.x : 0;
             if (x >= width)
             {
                 x = width - 1;
             }
 
-            std::size_t y = (p.y > 0) ? static_cast<std::size_t>(p.y) : 0;
+            int y = (p.y > 0) ? p.y : 0;
             if (y >= height)
             {
                 y = height - 1;
@@ -383,8 +385,8 @@ namespace rwe
                 return std::nullopt;
             }
 
-            auto x1 = static_cast<std::size_t>(p.x);
-            auto y1 = static_cast<std::size_t>(p.y);
+            auto x1 = p.x;
+            auto y1 = p.y;
 
             if (x1 >= width || y1 >= height)
             {
@@ -405,7 +407,7 @@ namespace rwe
         }
 
         template <typename U, typename Func>
-        void transformAndReplace(std::size_t x, std::size_t y, const Grid<U>& replacement, Func f)
+        void transformAndReplace(int x, int y, const Grid<U>& replacement, Func f)
         {
             if (x + replacement.getWidth() > getWidth() || y + replacement.getHeight() > getHeight())
             {
@@ -416,7 +418,7 @@ namespace rwe
         }
 
         template <typename U, typename Func>
-        void transformAndReplace(std::size_t x, std::size_t y, std::size_t regionWidth, std::size_t regionHeight, const Grid<U>& replacement, Func f)
+        void transformAndReplace(int x, int y, int regionWidth, int regionHeight, const Grid<U>& replacement, Func f)
         {
             if (x + regionWidth > getWidth() || y + regionHeight > getHeight())
             {
@@ -447,8 +449,8 @@ namespace rwe
                 return GridRegion(0, 0, 0, 0);
             }
             return GridRegion(
-                static_cast<unsigned int>(intersect->x), // guaranteed non-negative
-                static_cast<unsigned int>(intersect->y), // guaranteed non-negative
+                intersect->x, // guaranteed non-negative
+                intersect->y, // guaranteed non-negative
                 intersect->width,
                 intersect->height);
         }

--- a/src/rwe/io/featuretdf/FeatureDefinition.test.cpp
+++ b/src/rwe/io/featuretdf/FeatureDefinition.test.cpp
@@ -95,7 +95,7 @@ namespace rwe
             REQUIRE(f.reproduce == false);
             REQUIRE(f.reproduceArea == 6);
 
-            REQUIRE(f.blocking == 1);
+            REQUIRE(f.blocking == true);
             REQUIRE(f.hitDensity == 10);
 
             // fields not provided

--- a/src/rwe/math/Vector3f.test.cpp
+++ b/src/rwe/math/Vector3f.test.cpp
@@ -256,9 +256,9 @@ namespace rwe
             // observed in playtesting,
             // this can cause NaN to be emitted by acos
             // due to floating point error in the input
-            Vector3f a(171.99025, -0.00849914551, -38.2367249);
-            Vector3f b(171.99025, 0, -38.2367249);
-            Vector3f n(38.2367249, -0, 171.99025);
+            Vector3f a(171.99025f, -0.00849914551f, -38.2367249f);
+            Vector3f b(171.99025f, 0.f, -38.2367249f);
+            Vector3f n(38.2367249f, -0.f, 171.99025f);
             REQUIRE(angleTo(a, b, n) == Approx(0.0f));
         }
     }

--- a/src/rwe/network_util.cpp
+++ b/src/rwe/network_util.cpp
@@ -21,7 +21,7 @@ namespace rwe
             | (static_cast<unsigned int>(static_cast<unsigned char>(buffer[1])) << 8u)
             | (static_cast<unsigned int>(static_cast<unsigned char>(buffer[0])));
     }
-    unsigned int computeCrc(const char* buffer, unsigned int size)
+    unsigned int computeCrc(const char* buffer, int size)
     {
         // throw in a CRC to verify the message
         boost::crc_32_type crc;

--- a/src/rwe/network_util.h
+++ b/src/rwe/network_util.h
@@ -28,5 +28,5 @@ namespace rwe
 
     unsigned int readInt(const char* buffer);
 
-    unsigned int computeCrc(const char* buffer, unsigned int size);
+    unsigned int computeCrc(const char* buffer, int size);
 }

--- a/src/rwe/pathfinding/PathFindingService.cpp
+++ b/src/rwe/pathfinding/PathFindingService.cpp
@@ -108,8 +108,8 @@ namespace rwe
     {
         auto corner = simulation->terrain.heightmapIndexToWorldCorner(rect.x, rect.y);
 
-        auto halfWorldWidth = (SimScalar(rect.width) * MapTerrain::HeightTileWidthInWorldUnits) / 2_ss;
-        auto halfWorldHeight = (SimScalar(rect.height) * MapTerrain::HeightTileHeightInWorldUnits) / 2_ss;
+        auto halfWorldWidth = (simScalarFromInt(rect.width) * MapTerrain::HeightTileWidthInWorldUnits) / 2_ss;
+        auto halfWorldHeight = (simScalarFromInt(rect.height) * MapTerrain::HeightTileHeightInWorldUnits) / 2_ss;
 
         auto center = corner + SimVector(halfWorldWidth, 0_ss, halfWorldHeight);
         center.y = simulation->terrain.getHeightAt(center.x, center.z);

--- a/src/rwe/render/GlMesh.cpp
+++ b/src/rwe/render/GlMesh.cpp
@@ -5,10 +5,10 @@ namespace rwe
     GlMesh::GlMesh(
         VaoHandle&& vao,
         VboHandle&& vbo,
-        unsigned int vertexCount)
+        size_t vertexCount)
         : vao(std::move(vao)),
           vbo(std::move(vbo)),
-          vertexCount(vertexCount)
+          vertexCount(static_cast<int>(vertexCount))
     {
     }
 }

--- a/src/rwe/render/GlMesh.h
+++ b/src/rwe/render/GlMesh.h
@@ -9,8 +9,8 @@ namespace rwe
     {
         VaoHandle vao;
         VboHandle vbo;
-        unsigned int vertexCount;
+        int vertexCount;
 
-        GlMesh(VaoHandle&& vao, VboHandle&& vbo, unsigned int vertexCount);
+        GlMesh(VaoHandle&& vao, VboHandle&& vbo, size_t vertexCount);
     };
 }

--- a/src/rwe/render/GraphicsContext.cpp
+++ b/src/rwe/render/GraphicsContext.cpp
@@ -125,7 +125,7 @@ namespace rwe
     TextureArrayHandle GraphicsContext::createTextureArray(unsigned int width, unsigned int height, unsigned int mipMapLevels, std::vector<Color>& images)
     {
         assert(images.size() % (width * height) == 0);
-        auto depth = images.size() / (width * height);
+        GLsizei depth = static_cast<GLsizei>(images.size()) / (width * height);
         GLuint texture;
         glGenTextures(1, &texture);
         TextureArrayIdentifier id(texture);
@@ -205,7 +205,7 @@ namespace rwe
     ShaderHandle GraphicsContext::compileShader(GLenum shaderType, const std::string& source)
     {
         auto data = source.data();
-        GLint length = source.size();
+        GLint length = static_cast<int>(source.size());
         ShaderHandle shader(ShaderIdentifier(glCreateShader(shaderType)));
         glShaderSource(shader.get().value, 1, &data, &length);
         glCompileShader(shader.get().value);

--- a/src/rwe/sim/GameSimulation.cpp
+++ b/src/rwe/sim/GameSimulation.cpp
@@ -107,7 +107,7 @@ namespace rwe
 
     PlayerId GameSimulation::addPlayer(const GamePlayerInfo& info)
     {
-        PlayerId id(players.size());
+        PlayerId id(static_cast<int>(players.size()));
         players.push_back(info);
         return id;
     }
@@ -490,7 +490,7 @@ namespace rwe
                 }
                 else
                 {
-                    livingPlayer = PlayerId(i);
+                    livingPlayer = PlayerId(static_cast<int>(i));
                 }
             }
         }

--- a/src/rwe/sim/MapTerrain.cpp
+++ b/src/rwe/sim/MapTerrain.cpp
@@ -26,7 +26,7 @@ namespace rwe
 
     SimVector MapTerrain::heightmapIndexToWorldCorner(int x, int y) const
     {
-        return heightmapToWorldSpace(SimVector(SimScalar(x), 0_ss, SimScalar(y)));
+        return heightmapToWorldSpace(SimVector(simScalarFromInt(x), 0_ss, simScalarFromInt(y)));
     }
 
     SimVector MapTerrain::heightmapIndexToWorldCorner(Point p) const
@@ -36,12 +36,12 @@ namespace rwe
 
     SimVector MapTerrain::heightmapIndexToWorldCenter(int x, int y) const
     {
-        return heightmapToWorldSpace(SimVector(SimScalar(x) + 0.5_ssf, 0_ss, SimScalar(y) + 0.5_ssf));
+        return heightmapToWorldSpace(SimVector(simScalarFromInt(x) + 0.5_ssf, 0_ss, simScalarFromInt(y) + 0.5_ssf));
     }
 
     SimVector MapTerrain::heightmapIndexToWorldCenter(std::size_t x, std::size_t y) const
     {
-        return heightmapToWorldSpace(SimVector(SimScalar(x) + 0.5_ssf, 0_ss, SimScalar(y) + 0.5_ssf));
+        return heightmapToWorldSpace(SimVector(SimScalar(static_cast<float>(x)) + 0.5_ssf, 0_ss, SimScalar(static_cast<float>(y)) + 0.5_ssf));
     }
 
     SimVector MapTerrain::heightmapIndexToWorldCenter(Point p) const
@@ -71,23 +71,23 @@ namespace rwe
 
     SimScalar MapTerrain::leftInWorldUnits() const
     {
-        return -((SimScalar(heights.getWidth()) / 2_ss) * HeightTileWidthInWorldUnits);
+        return -((simScalarFromInt(heights.getWidth()) / 2_ss) * HeightTileWidthInWorldUnits);
     }
 
     SimScalar MapTerrain::rightCutoffInWorldUnits() const
     {
-        auto right = (SimScalar(heights.getWidth()) / 2_ss) * HeightTileWidthInWorldUnits;
+        auto right = (simScalarFromInt(heights.getWidth()) / 2_ss) * HeightTileWidthInWorldUnits;
         return right - (HeightTileWidthInWorldUnits * 2_ss);
     }
 
     SimScalar MapTerrain::topInWorldUnits() const
     {
-        return -((SimScalar(heights.getHeight()) / 2_ss) * HeightTileHeightInWorldUnits);
+        return -((simScalarFromInt(heights.getHeight()) / 2_ss) * HeightTileHeightInWorldUnits);
     }
 
     SimScalar MapTerrain::bottomCutoffInWorldUnits() const
     {
-        auto bottom = (SimScalar(heights.getHeight()) / 2_ss) * HeightTileHeightInWorldUnits;
+        auto bottom = (simScalarFromInt(heights.getHeight()) / 2_ss) * HeightTileHeightInWorldUnits;
         return bottom - (HeightTileHeightInWorldUnits * 8_ss);
     }
 
@@ -98,12 +98,12 @@ namespace rwe
 
     SimScalar MapTerrain::getWidthInWorldUnits() const
     {
-        return SimScalar(heights.getWidth()) * HeightTileWidthInWorldUnits;
+        return simScalarFromInt(heights.getWidth()) * HeightTileWidthInWorldUnits;
     }
 
     SimScalar MapTerrain::getHeightInWorldUnits() const
     {
-        return SimScalar(heights.getHeight()) * HeightTileHeightInWorldUnits;
+        return simScalarFromInt(heights.getHeight()) * HeightTileHeightInWorldUnits;
     }
 
     SimVector MapTerrain::topLeftCoordinateToWorld(const SimVector& pos) const
@@ -149,13 +149,13 @@ namespace rwe
 
         auto xDirection = ray.direction.x > 0_ss ? 1 : -1;
         auto zDirection = ray.direction.z > 0_ss ? 1 : -1;
-        auto xPlaneOffset = (HeightTileWidthInWorldUnits / 2_ss) * SimScalar(xDirection);
-        auto zPlaneOffset = (HeightTileHeightInWorldUnits / 2_ss) * SimScalar(zDirection);
+        auto xPlaneOffset = (HeightTileWidthInWorldUnits / 2_ss) * simScalarFromInt(xDirection);
+        auto zPlaneOffset = (HeightTileHeightInWorldUnits / 2_ss) * simScalarFromInt(zDirection);
 
         while (true)
         {
-            auto neighbourX = (heightmapPosition.x - SimScalar(startCell.x)) > 0.5_ssf ? 1 : -1;
-            auto neighbourY = (heightmapPosition.z - SimScalar(startCell.y)) > 0.5_ssf ? 1 : -1;
+            auto neighbourX = (heightmapPosition.x - simScalarFromInt(startCell.x)) > 0.5_ssf ? 1 : -1;
+            auto neighbourY = (heightmapPosition.z - simScalarFromInt(startCell.y)) > 0.5_ssf ? 1 : -1;
 
             // Due to floating-point precision issues,
             // when the line passes very close to a cell boundary
@@ -221,7 +221,7 @@ namespace rwe
                 }
 
                 startCell.x += xDirection;
-                heightmapPosition.x += SimScalar(xDirection);
+                heightmapPosition.x += simScalarFromInt(xDirection);
             }
             else
             {
@@ -231,7 +231,7 @@ namespace rwe
                 }
 
                 startCell.y += zDirection;
-                heightmapPosition.z += SimScalar(zDirection);
+                heightmapPosition.z += simScalarFromInt(zDirection);
             }
         }
     }

--- a/src/rwe/sim/PlayerId.h
+++ b/src/rwe/sim/PlayerId.h
@@ -5,5 +5,5 @@
 namespace rwe
 {
     struct PlayerIdTag;
-    using PlayerId = OpaqueId<unsigned int, PlayerIdTag>;
+    using PlayerId = OpaqueId<int, PlayerIdTag>;
 }

--- a/src/rwe/sim/SimScalar.h
+++ b/src/rwe/sim/SimScalar.h
@@ -9,12 +9,12 @@ namespace rwe
 
     constexpr SimScalar operator"" _ss(unsigned long long val)
     {
-        return SimScalar(val);
+        return SimScalar(static_cast<float>(val));
     }
 
     constexpr SimScalar operator"" _ssf(long double val)
     {
-        return SimScalar(val);
+        return SimScalar(static_cast<float>(val));
     }
 
     inline float simScalarToFloat(SimScalar s)
@@ -30,6 +30,16 @@ namespace rwe
     inline unsigned int simScalarToUInt(SimScalar s)
     {
         return static_cast<unsigned int>(s.value);
+    }
+
+    inline SimScalar simScalarFromUInt(unsigned int i)
+    {
+        return SimScalar(static_cast<float>(i));
+    }
+
+    inline SimScalar simScalarFromInt(int i)
+    {
+        return SimScalar(static_cast<float>(i));
     }
 
     inline int roundToInt(SimScalar s)

--- a/src/rwe/sim/Unit.cpp
+++ b/src/rwe/sim/Unit.cpp
@@ -440,7 +440,7 @@ namespace rwe
         bool operator()(const UnitWeaponStateAttacking& state) const { return std::visit(TargetIsPositionVisitor(position), state.target); }
     };
 
-    void Unit::setWeaponTarget(unsigned int weaponIndex, UnitId target)
+    void Unit::setWeaponTarget(int weaponIndex, UnitId target)
     {
         auto& weapon = weapons[weaponIndex];
         if (!weapon)
@@ -455,7 +455,7 @@ namespace rwe
         }
     }
 
-    void Unit::setWeaponTarget(unsigned int weaponIndex, const SimVector& target)
+    void Unit::setWeaponTarget(int weaponIndex, const SimVector& target)
     {
         auto& weapon = weapons[weaponIndex];
         if (!weapon)
@@ -470,7 +470,7 @@ namespace rwe
         }
     }
 
-    void Unit::clearWeaponTarget(unsigned int weaponIndex)
+    void Unit::clearWeaponTarget(int weaponIndex)
     {
         auto& weapon = weapons[weaponIndex];
         if (!weapon)
@@ -479,14 +479,14 @@ namespace rwe
         }
 
         weapon->state = UnitWeaponStateIdle();
-        cobEnvironment->createThread("TargetCleared", {static_cast<int>(weaponIndex)});
+        cobEnvironment->createThread("TargetCleared", {weaponIndex});
     }
 
     void Unit::clearWeaponTargets()
     {
         for (Index i = 0; i < getSize(weapons); ++i)
         {
-            clearWeaponTarget(i);
+            clearWeaponTarget(static_cast<int>(i));
         }
     }
 

--- a/src/rwe/sim/Unit.h
+++ b/src/rwe/sim/Unit.h
@@ -338,9 +338,9 @@ namespace rwe
 
         void addOrder(const UnitOrder& order);
 
-        void setWeaponTarget(unsigned int weaponIndex, UnitId target);
-        void setWeaponTarget(unsigned int weaponIndex, const SimVector& target);
-        void clearWeaponTarget(unsigned int weaponIndex);
+        void setWeaponTarget(int weaponIndex, UnitId target);
+        void setWeaponTarget(int weaponIndex, const SimVector& target);
+        void clearWeaponTarget(int weaponIndex);
         void clearWeaponTargets();
 
         Matrix4x<SimScalar> getTransform() const;

--- a/src/rwe/sim/UnitBehaviorService.cpp
+++ b/src/rwe/sim/UnitBehaviorService.cpp
@@ -118,7 +118,7 @@ namespace rwe
 
             for (Index i = 0; i < getSize(unit.weapons); ++i)
             {
-                updateWeapon(unitId, i);
+                updateWeapon(unitId, static_cast<int>(i));
             }
         }
 
@@ -255,7 +255,7 @@ namespace rwe
         return false;
     }
 
-    void UnitBehaviorService::updateWeapon(UnitId id, unsigned int weaponIndex)
+    void UnitBehaviorService::updateWeapon(UnitId id, int weaponIndex)
     {
         auto& unit = scene->getSimulation().getUnit(id);
         auto& weapon = unit.weapons[weaponIndex];
@@ -410,7 +410,7 @@ namespace rwe
         return rotateDirectionXZ(direction, angle);
     }
 
-    void UnitBehaviorService::tryFireWeapon(UnitId id, unsigned int weaponIndex)
+    void UnitBehaviorService::tryFireWeapon(UnitId id, int weaponIndex)
     {
         auto& unit = scene->getSimulation().getUnit(id);
         auto& weapon = unit.weapons[weaponIndex];
@@ -653,7 +653,7 @@ namespace rwe
         return true;
     }
 
-    std::string UnitBehaviorService::getAimScriptName(unsigned int weaponIndex) const
+    std::string UnitBehaviorService::getAimScriptName(int weaponIndex) const
     {
         switch (weaponIndex)
         {
@@ -668,7 +668,7 @@ namespace rwe
         }
     }
 
-    std::string UnitBehaviorService::getAimFromScriptName(unsigned int weaponIndex) const
+    std::string UnitBehaviorService::getAimFromScriptName(int weaponIndex) const
     {
         switch (weaponIndex)
         {
@@ -683,7 +683,7 @@ namespace rwe
         }
     }
 
-    std::string UnitBehaviorService::getFireScriptName(unsigned int weaponIndex) const
+    std::string UnitBehaviorService::getFireScriptName(int weaponIndex) const
     {
         switch (weaponIndex)
         {
@@ -698,7 +698,7 @@ namespace rwe
         }
     }
 
-    std::string UnitBehaviorService::getQueryScriptName(unsigned int weaponIndex) const
+    std::string UnitBehaviorService::getQueryScriptName(int weaponIndex) const
     {
         switch (weaponIndex)
         {
@@ -732,13 +732,13 @@ namespace rwe
         return result;
     }
 
-    SimVector UnitBehaviorService::getAimingPoint(UnitId id, unsigned int weaponIndex)
+    SimVector UnitBehaviorService::getAimingPoint(UnitId id, int weaponIndex)
     {
         const auto& unit = scene->getSimulation().getUnit(id);
         return unit.getTransform() * getLocalAimingPoint(id, weaponIndex);
     }
 
-    SimVector UnitBehaviorService::getLocalAimingPoint(UnitId id, unsigned int weaponIndex)
+    SimVector UnitBehaviorService::getLocalAimingPoint(UnitId id, int weaponIndex)
     {
         auto scriptName = getAimFromScriptName(weaponIndex);
         auto pieceId = runCobQuery(id, scriptName);
@@ -750,13 +750,13 @@ namespace rwe
         return getPieceLocalPosition(id, *pieceId);
     }
 
-    SimVector UnitBehaviorService::getFiringPoint(UnitId id, unsigned int weaponIndex)
+    SimVector UnitBehaviorService::getFiringPoint(UnitId id, int weaponIndex)
     {
         const auto& unit = scene->getSimulation().getUnit(id);
         return unit.getTransform() * getLocalFiringPoint(id, weaponIndex);
     }
 
-    SimVector UnitBehaviorService::getLocalFiringPoint(UnitId id, unsigned int weaponIndex)
+    SimVector UnitBehaviorService::getLocalFiringPoint(UnitId id, int weaponIndex)
     {
 
         auto scriptName = getQueryScriptName(weaponIndex);
@@ -860,7 +860,7 @@ namespace rwe
         else
         {
             // we're in range, aim weapons
-            for (unsigned int i = 0; i < 2; ++i)
+            for (int i = 0; i < 2; ++i)
             {
                 match(
                     target,
@@ -1099,7 +1099,7 @@ namespace rwe
         return getPiecePosition(id, *pieceId);
     }
 
-    SimVector UnitBehaviorService::getPieceLocalPosition(UnitId id, unsigned int pieceId)
+    SimVector UnitBehaviorService::getPieceLocalPosition(UnitId id, int pieceId)
     {
         auto& unit = scene->getSimulation().getUnit(id);
 
@@ -1109,7 +1109,7 @@ namespace rwe
         return pieceTransform * SimVector(0_ss, 0_ss, 0_ss);
     }
 
-    SimVector UnitBehaviorService::getPiecePosition(UnitId id, unsigned int pieceId)
+    SimVector UnitBehaviorService::getPiecePosition(UnitId id, int pieceId)
     {
         auto& unit = scene->getSimulation().getUnit(id);
 
@@ -1121,7 +1121,7 @@ namespace rwe
         return atan2(lhs.det(rhs), lhs.dot(rhs));
     }
 
-    SimAngle UnitBehaviorService::getPieceXZRotation(UnitId id, unsigned int pieceId)
+    SimAngle UnitBehaviorService::getPieceXZRotation(UnitId id, int pieceId)
     {
         auto& unit = scene->getSimulation().getUnit(id);
 

--- a/src/rwe/sim/UnitBehaviorService.h
+++ b/src/rwe/sim/UnitBehaviorService.h
@@ -67,11 +67,11 @@ namespace rwe
 
         bool followPath(Unit& unit, PathFollowingInfo& path);
 
-        void updateWeapon(UnitId id, unsigned int weaponIndex);
+        void updateWeapon(UnitId id, int weaponIndex);
 
         SimVector changeDirectionByRandomAngle(const SimVector& direction, SimAngle maxAngle);
 
-        void tryFireWeapon(UnitId id, unsigned int weaponIndex);
+        void tryFireWeapon(UnitId id, int weaponIndex);
 
         void applyUnitSteering(UnitId id);
         void updateUnitRotation(UnitId id);
@@ -81,25 +81,25 @@ namespace rwe
 
         bool tryApplyMovementToPosition(UnitId id, const SimVector& newPosition);
 
-        std::string getAimScriptName(unsigned int weaponIndex) const;
-        std::string getAimFromScriptName(unsigned int weaponIndex) const;
-        std::string getFireScriptName(unsigned int weaponIndex) const;
-        std::string getQueryScriptName(unsigned int weaponIndex) const;
+        std::string getAimScriptName(int weaponIndex) const;
+        std::string getAimFromScriptName(int weaponIndex) const;
+        std::string getFireScriptName(int weaponIndex) const;
+        std::string getQueryScriptName(int weaponIndex) const;
 
         std::optional<int> runCobQuery(UnitId id, const std::string& name);
 
-        SimVector getAimingPoint(UnitId id, unsigned int weaponIndex);
-        SimVector getLocalAimingPoint(UnitId id, unsigned int weaponIndex);
+        SimVector getAimingPoint(UnitId id, int weaponIndex);
+        SimVector getLocalAimingPoint(UnitId id, int weaponIndex);
 
-        SimVector getFiringPoint(UnitId id, unsigned int weaponIndex);
-        SimVector getLocalFiringPoint(UnitId id, unsigned int weaponIndex);
+        SimVector getFiringPoint(UnitId id, int weaponIndex);
+        SimVector getLocalFiringPoint(UnitId id, int weaponIndex);
 
         SimVector getNanoPoint(UnitId id);
 
-        SimVector getPieceLocalPosition(UnitId id, unsigned int pieceId);
-        SimVector getPiecePosition(UnitId id, unsigned int pieceId);
+        SimVector getPieceLocalPosition(UnitId id, int pieceId);
+        SimVector getPiecePosition(UnitId id, int pieceId);
 
-        SimAngle getPieceXZRotation(UnitId id, unsigned int pieceId);
+        SimAngle getPieceXZRotation(UnitId id, int pieceId);
 
         struct BuildPieceInfo
         {

--- a/src/rwe/ui/UiComponent.cpp
+++ b/src/rwe/ui/UiComponent.cpp
@@ -46,12 +46,12 @@ namespace rwe
         name = std::move(newName);
     }
 
-    unsigned int UiComponent::getGroup() const
+    int UiComponent::getGroup() const
     {
         return group;
     }
 
-    void UiComponent::setGroup(unsigned int newGroup)
+    void UiComponent::setGroup(int newGroup)
     {
         group = newGroup;
     }

--- a/src/rwe/ui/UiComponent.h
+++ b/src/rwe/ui/UiComponent.h
@@ -16,8 +16,8 @@ namespace rwe
         int posX;
         int posY;
 
-        unsigned int sizeX;
-        unsigned int sizeY;
+        int sizeX;
+        int sizeY;
 
         std::string name;
         unsigned int group{0};
@@ -31,7 +31,7 @@ namespace rwe
         std::vector<std::unique_ptr<Subscription>> subscriptions;
 
     public:
-        UiComponent(int posX, int posY, unsigned int sizeX, unsigned int sizeY)
+        UiComponent(int posX, int posY, int sizeX, int sizeY)
             : posX(posX), posY(posY), sizeX(sizeX), sizeY(sizeY)
         {
         }
@@ -43,9 +43,9 @@ namespace rwe
 
         virtual ~UiComponent();
 
-        unsigned int getWidth() { return sizeX; }
+        int getWidth() { return sizeX; }
 
-        unsigned int getHeight() { return sizeY; }
+        int getHeight() { return sizeY; }
 
         int getX() { return posX; }
         int getY() { return posY; }
@@ -91,8 +91,8 @@ namespace rwe
         void setName(const std::string& newName);
         void setName(std::string&& newName);
 
-        unsigned int getGroup() const;
-        void setGroup(unsigned int newGroup);
+        int getGroup() const;
+        void setGroup(int newGroup);
 
         Observable<const ControlMessage&>& messages();
         const Observable<const ControlMessage&>& messages() const;

--- a/src/rwe/ui/UiFactory.cpp
+++ b/src/rwe/ui/UiFactory.cpp
@@ -39,10 +39,10 @@ namespace rwe
 
         auto texture = textureService->getBitmapRegion(
             background,
-            0,
-            0,
-            panelEntry.common.width,
-            panelEntry.common.height);
+            0.f,
+            0.f,
+            static_cast<float>(panelEntry.common.width),
+            static_cast<float>(panelEntry.common.height));
 
 
         // Adjust x and y pos such that the bottom and right edges of the panel
@@ -238,7 +238,7 @@ namespace rwe
     }
 
     std::unique_ptr<UiStagedButton>
-    UiFactory::createStagedButton(int x, int y, int width, int height, const std::string& guiName, const std::string& name, const std::vector<std::string>& labels, unsigned int stages)
+    UiFactory::createStagedButton(int x, int y, int width, int height, const std::string& guiName, const std::string& name, const std::vector<std::string>& labels, int stages)
     {
         auto sprites = getStagedButtonGraphics(guiName, name, stages);
 
@@ -389,7 +389,7 @@ namespace rwe
         return button;
     }
 
-    std::shared_ptr<SpriteSeries> UiFactory::getDefaultStagedButtonGraphics(const std::string& guiName, unsigned int stages)
+    std::shared_ptr<SpriteSeries> UiFactory::getDefaultStagedButtonGraphics(const std::string& guiName, int stages)
     {
         assert(stages >= 1 && stages <= 4);
         std::string entryName("stagebuttn");
@@ -404,7 +404,7 @@ namespace rwe
         // default behaviour
         const auto& sprite = textureService->getDefaultSprite();
         auto series = std::make_shared<SpriteSeries>();
-        for (unsigned int i = 0; i < stages; ++i)
+        for (int i = 0; i < stages; ++i)
         {
             series->sprites.push_back(sprite);
         }
@@ -567,7 +567,7 @@ namespace rwe
         auto stageCount = spriteCount > 3 ? spriteCount - 2 : 1;
 
         std::vector<std::shared_ptr<Sprite>> normalSprites;
-        for (unsigned int i = 0; i < stageCount; ++i)
+        for (int i = 0; i < stageCount; ++i)
         {
             normalSprites.push_back(sprites[i]);
         }
@@ -602,7 +602,7 @@ namespace rwe
         return UiFactory::ButtonSprites{std::vector<std::shared_ptr<Sprite>>{normalSprite}, pressedSprite, disabledSprite};
     }
 
-    UiFactory::ButtonSprites UiFactory::getStagedButtonGraphics(const std::string& guiName, const std::string& name, unsigned int stages)
+    UiFactory::ButtonSprites UiFactory::getStagedButtonGraphics(const std::string& guiName, const std::string& name, int stages)
     {
         auto graphics = textureService->getGuiTexture(guiName, name);
         if (!graphics)
@@ -613,17 +613,17 @@ namespace rwe
         auto defaultSprite = textureService->getDefaultSprite();
 
         const auto& sprites = (*graphics)->sprites;
-        auto spriteCount = sprites.size();
+        auto spriteCount = static_cast<int>(sprites.size());
 
         auto stagesPresentCount = spriteCount > 2 ? spriteCount - 2 : 0;
-        auto stagesToCopyCount = std::min<unsigned int>(stages, stagesPresentCount);
+        auto stagesToCopyCount = std::min<int>(stages, stagesPresentCount);
 
         std::vector<std::shared_ptr<Sprite>> normalSprites;
-        for (unsigned int i = 0; i < stagesToCopyCount; ++i)
+        for (int i = 0; i < stagesToCopyCount; ++i)
         {
             normalSprites.push_back(sprites[i]);
         }
-        for (unsigned int i = stagesToCopyCount; i < stages; ++i)
+        for (int i = stagesToCopyCount; i < stages; ++i)
         {
             normalSprites.push_back(defaultSprite);
         }

--- a/src/rwe/ui/UiFactory.h
+++ b/src/rwe/ui/UiFactory.h
@@ -51,7 +51,7 @@ namespace rwe
 
         std::unique_ptr<UiStagedButton> createBasicButton(int x, int y, int width, int height, const std::string& guiName, const std::string& name, const std::string& label);
 
-        std::unique_ptr<UiStagedButton> createStagedButton(int x, int y, int width, int height, const std::string& guiName, const std::string& name, const std::vector<std::string>& labels, unsigned int stages);
+        std::unique_ptr<UiStagedButton> createStagedButton(int x, int y, int width, int height, const std::string& guiName, const std::string& name, const std::vector<std::string>& labels, int stages);
 
     private:
         std::unique_ptr<UiComponent> componentFromGuiEntry(const std::string& guiName, const GuiEntry& entry);
@@ -74,7 +74,7 @@ namespace rwe
 
         std::optional<AudioService::SoundHandle> deduceButtonSound(const std::string& guiName, const std::string& name, int width, int height);
 
-        std::shared_ptr<SpriteSeries> getDefaultStagedButtonGraphics(const std::string& guiName, unsigned int stages);
+        std::shared_ptr<SpriteSeries> getDefaultStagedButtonGraphics(const std::string& guiName, int stages);
 
         std::unique_ptr<UiComponent> surfaceFromGuiEntry(const std::string& guiName, const GuiEntry& entry);
 
@@ -82,6 +82,6 @@ namespace rwe
 
         ButtonSprites getBasicButtonGraphics(const std::string& guiName, const std::string& name, int width, int height);
 
-        ButtonSprites getStagedButtonGraphics(const std::string& guiName, const std::string& name, unsigned int stages);
+        ButtonSprites getStagedButtonGraphics(const std::string& guiName, const std::string& name, int stages);
     };
 }

--- a/src/rwe/ui/UiLabel.cpp
+++ b/src/rwe/ui/UiLabel.cpp
@@ -8,10 +8,10 @@ namespace rwe
         switch (alignment)
         {
             case Alignment::Left:
-                context.drawTextWrapped(Rectangle2f::fromTopLeft(posX, posY + 12.0f, sizeX, sizeY), text, *font);
+                context.drawTextWrapped(Rectangle2f::fromTopLeft(static_cast<float>(posX), posY + 12.0f, static_cast<float>(sizeX), static_cast<float>(sizeY)), text, *font);
                 break;
             case Alignment::Center:
-                context.drawTextCentered(posX, posY, text, *font);
+                context.drawTextCentered(static_cast<float>(posX), static_cast<float>(posY), text, *font);
                 break;
         }
     }

--- a/src/rwe/ui/UiLightBar.cpp
+++ b/src/rwe/ui/UiLightBar.cpp
@@ -11,7 +11,7 @@ namespace rwe
     void UiLightBar::render(UiRenderService& context) const
     {
         auto color = percentComplete == 1.0f ? Color(83, 223, 79) : Color(255, 71, 0);
-        context.fillColor(posX, posY, sizeX * percentComplete, sizeY, color);
+        context.fillColor(static_cast<float>(posX), static_cast<float>(posY), sizeX * percentComplete, static_cast<float>(sizeY), color);
 
         context.drawSpriteAbs(posX, posY, sizeX, sizeY, *lightMask);
     }

--- a/src/rwe/ui/UiListBox.cpp
+++ b/src/rwe/ui/UiListBox.cpp
@@ -17,17 +17,17 @@ namespace rwe
 
     void UiListBox::render(UiRenderService& context) const
     {
-        auto lines = std::min<unsigned int>(numberOfLines(), items.size());
+        auto lines = std::min<unsigned int>(numberOfLines(), static_cast<unsigned int>(items.size()));
 
         for (unsigned int i = 0; i < lines; ++i)
         {
-            float y = 12.0f + (i * 12.0f);
+            int y = 12 + (i * 12);
             auto itemIndex = scrollPositionSubject.getValue() + i;
 
             const auto& selectedIndexValue = selectedIndexSubject.getValue();
             if (selectedIndexValue && itemIndex == *selectedIndexValue)
             {
-                context.fillColor(posX, posY + y - 11.0f, sizeX, 12.0f, Color(255, 255, 255, 31));
+                context.fillColor(static_cast<float>(posX), posY + y - 11.0f, static_cast<float>(sizeX), 12.0f, Color(255, 255, 255, 31));
             }
 
             const auto& e = items[itemIndex];

--- a/src/rwe/ui/UiPanel.cpp
+++ b/src/rwe/ui/UiPanel.cpp
@@ -45,11 +45,11 @@ namespace rwe
     {
         if (background)
         {
-            graphics.drawSpriteAbs(posX, posY, **background);
+            graphics.drawSpriteAbs(static_cast<float>(posX), static_cast<float>(posY), **background);
         }
 
         graphics.pushMatrix();
-        graphics.multiplyMatrix(Matrix4f::translation(Vector3f(posX, posY, 0.0f)));
+        graphics.multiplyMatrix(Matrix4f::translation(Vector3f(static_cast<float>(posX), static_cast<float>(posY), 0.0f)));
 
         for (const auto& i : children)
         {

--- a/src/rwe/ui/UiScrollBar.cpp
+++ b/src/rwe/ui/UiScrollBar.cpp
@@ -9,7 +9,7 @@ namespace rwe
 
     void UiScrollBar::render(UiRenderService& context) const
     {
-        drawScrollBackground(context, posX, posY, sizeY);
+        drawScrollBackground(context, static_cast<float>(posX), static_cast<float>(posY), static_cast<float>(sizeY));
 
         auto info = getScrollBoxInfo();
 
@@ -19,8 +19,8 @@ namespace rwe
     UiScrollBar::UiScrollBar(
         int posX,
         int posY,
-        unsigned int sizeX,
-        unsigned int sizeY,
+        int sizeX,
+        int sizeY,
         std::shared_ptr<SpriteSeries> sprites)
         : UiComponent(posX, posY, sizeX, sizeY),
           sprites(std::move(sprites))
@@ -94,7 +94,7 @@ namespace rwe
     void UiScrollBar::mouseDown(MouseButtonEvent event)
     {
         const Sprite& upArrow = *sprites->sprites[6];
-        if (Rectangle2f::fromTopLeft(posX, posY, upArrow.bounds.width(), upArrow.bounds.height()).contains(event.x, event.y))
+        if (Rectangle2f::fromTopLeft(static_cast<float>(posX), static_cast<float>(posY), upArrow.bounds.width(), upArrow.bounds.height()).contains(static_cast<float>(event.x), static_cast<float>(event.y)))
         {
             upArrowPressed = true;
             scrollUpSubject.next(true);
@@ -102,7 +102,7 @@ namespace rwe
         }
 
         const Sprite& downArrow = *sprites->sprites[8];
-        if (Rectangle2f::fromTopLeft(posX, posY + sizeY - downArrow.bounds.height(), downArrow.bounds.width(), downArrow.bounds.height()).contains(event.x, event.y))
+        if (Rectangle2f::fromTopLeft(static_cast<float>(posX), posY + sizeY - downArrow.bounds.height(), downArrow.bounds.width(), downArrow.bounds.height()).contains(static_cast<float>(event.x), static_cast<float>(event.y)))
         {
             downArrowPressed = true;
             scrollDownSubject.next(true);
@@ -110,7 +110,7 @@ namespace rwe
         }
 
         auto boxInfo = getScrollBoxInfo();
-        if (Rectangle2f::fromTopLeft(posX, posY + boxInfo.pos, sizeX, boxInfo.size).contains(event.x, event.y))
+        if (Rectangle2f::fromTopLeft(static_cast<float>(posX), posY + boxInfo.pos, static_cast<float>(sizeX), boxInfo.size).contains(static_cast<float>(event.x), static_cast<float>(event.y)))
         {
             barGrabbed = true;
             mouseDownY = event.y;
@@ -187,7 +187,7 @@ namespace rwe
 
         if (backgroundPressed)
         {
-            auto cursorPercent = toScrollPercent(mouseY - posY);
+            auto cursorPercent = toScrollPercent(static_cast<float>(mouseY - posY));
 
             auto boxTopPercent = scrollPercent * (1.0f - getEffectiveScrollBarPercent());
 

--- a/src/rwe/ui/UiScrollBar.h
+++ b/src/rwe/ui/UiScrollBar.h
@@ -52,8 +52,8 @@ namespace rwe
         UiScrollBar(
             int posX,
             int posY,
-            unsigned int sizeX,
-            unsigned int sizeY,
+            int sizeX,
+            int sizeY,
             std::shared_ptr<SpriteSeries> sprites);
 
         void render(UiRenderService& context) const override;

--- a/src/rwe/ui/UiStagedButton.cpp
+++ b/src/rwe/ui/UiStagedButton.cpp
@@ -22,7 +22,7 @@ namespace rwe
     {
         const auto& sprite = pressed || toggledOn ? *pressedSprite : *stages[currentStage].sprite;
 
-        graphics.drawSpriteAbs(posX, posY, sprite);
+        graphics.drawSpriteAbs(static_cast<float>(posX), static_cast<float>(posY), sprite);
 
         const auto& label = stages[currentStage].label;
         switch (textAlign)
@@ -56,7 +56,7 @@ namespace rwe
             case TextAlign::BottomCenter:
             {
                 float textX = posX + (sizeX / 2.0f);
-                float textY = posY + sizeY - 7;
+                float textY = posY + sizeY - 7.f;
                 if (pressed)
                 {
                     textX += 1.0f;


### PR DESCRIPTION
I cleared out as much of the low-hanging warnings as I could, while eliminating a lot of unsigned types. The remaining warnings are:

things I think need some genuine attention or further thought before burying
things I didn't understand
protobufs code... I attempted to set the protobuf include directories as SYSTEM to try to make Visual Studio stop reporting those warnings, but it didn't work. Likely related: https://developercommunity.visualstudio.com/t/visual-studio-with-cmake-cannot-ignore-warnings-fr/1006684
Kind of a bear because it touches everything, but most are very basic changes, tests all passed, the game ran fine for me, and build output is WAY more readable and useful. Hopefully from here we can continue whittling down warnings.