### PR TITLE
Update spdlog to v1.9.2 for compat w/ c++20 MSVC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@
 #include <rwe/ui/UiFactory.h>
 #include <rwe/util.h>
 #include <rwe/vfs/CompositeVirtualFileSystem.h>
-#include <spdlog/spdlog.h>
+#include <spdlog/sinks/basic_file_sink.h>
 
 namespace fs = boost::filesystem;
 namespace po = boost::program_options;


### PR DESCRIPTION
Should fix spdlog compilation errors with the latest Visual Studio 2019 (v16.11.0) set to std:c++latest (which was breaking recent appveyor test builds). Apparently related to new C++20 support.

I tested locally, fixed the build and rwe.log is being written to as it should.