### PR TITLE
Handle metal making units

### DIFF
--- a/src/rwe/sim/GameSimulation.cpp
+++ b/src/rwe/sim/GameSimulation.cpp
@@ -1446,6 +1446,12 @@ namespace rwe
                             auto metalValue = metalGrid.accumulate(metalGrid.clipRegion(footprint), 0u, std::plus<>());
                             addResourceDelta(unitId, Energy(0), Metal(metalValue * unitDefinition.extractsMetal.value));
                         }
+
+                        // make metal
+                        if (unitDefinition.makesMetal != Metal(0))
+                        {
+                            addResourceDelta(unitId, Energy(0), unitDefinition.makesMetal);
+                        }
                     }
 
                     unit.isSufficientlyPowered = addResourceDelta(unitId, -unitDefinition.energyUse, -unitDefinition.metalUse);


### PR DESCRIPTION
With this PR a unit's `makesMetal` value is added to a player's resources as long as that unit is activated and sufficiently powered.

![image](https://github.com/MHeasell/rwe/assets/14198435/b496293e-019b-4360-9acb-2903ce29a7d5)
