### PR TITLE
Wind generation and wind speed

### DIFF
--- a/src/rwe/LoadingScene.cpp
+++ b/src/rwe/LoadingScene.cpp
@@ -167,7 +167,7 @@ namespace rwe
 
         auto movementClassCollisionService = createMovementClassCollisionService(mapInfo.terrain, dataMaps.movementClassDatabase);
 
-        GameSimulation simulation(std::move(mapInfo.terrain), mapInfo.surfaceMetal);
+        GameSimulation simulation(std::move(mapInfo.terrain), mapInfo.surfaceMetal, mapInfo.minWindSpeed, mapInfo.maxWindSpeed);
 
         simulation.unitDefinitions = std::move(dataMaps.unitDefinitions);
         simulation.weaponDefinitions = std::move(dataMaps.weaponDefinitions);
@@ -375,7 +375,7 @@ namespace rwe
             features.emplace_back(Point(f.xPos, f.zPos), f.featureName);
         }
 
-        return LoadMapResult{std::move(terrain), static_cast<unsigned char>(schema.surfaceMetal), std::move(features), std::move(terrainGraphics)};
+        return LoadMapResult{std::move(terrain), static_cast<unsigned char>(schema.surfaceMetal), ota.minWindSpeed, ota.maxWindSpeed, std::move(features), std::move(terrainGraphics)};
     }
 
     std::vector<TextureArrayRegion> LoadingScene::getTileTextures(TntArchive& tnt)

--- a/src/rwe/LoadingScene.h
+++ b/src/rwe/LoadingScene.h
@@ -127,6 +127,8 @@ namespace rwe
         {
             MapTerrain terrain;
             unsigned char surfaceMetal;
+            int minWindSpeed;
+            int maxWindSpeed;
             std::vector<std::pair<Point, std::string>> features;
             MapTerrainGraphics terrainGraphics;
         };

--- a/src/rwe/LoadingScene_util.cpp
+++ b/src/rwe/LoadingScene_util.cpp
@@ -311,6 +311,8 @@ namespace rwe
         u.energyStorage = fbi.energyStorage;
         u.metalStorage = fbi.metalStorage;
 
+        u.windGenerator = fbi.windGenerator;
+
         u.corpse = fbi.corpse;
 
         u.hideDamage = fbi.hideDamage;

--- a/src/rwe/io/fbi/UnitFbi.h
+++ b/src/rwe/io/fbi/UnitFbi.h
@@ -77,6 +77,8 @@ namespace rwe
         Energy energyStorage;
         Metal metalStorage;
 
+        Energy windGenerator;
+
         bool hideDamage;
         bool showPlayerName;
 

--- a/src/rwe/io/fbi/io.cpp
+++ b/src/rwe/io/fbi/io.cpp
@@ -82,6 +82,7 @@ namespace rwe
         tdf.readOrDefault("ExtractsMetal", u.extractsMetal);
         tdf.readOrDefault("EnergyStorage", u.energyStorage);
         tdf.readOrDefault("MetalStorage", u.metalStorage);
+        tdf.readOrDefault("WindGenerator", u.windGenerator);
 
         tdf.readOrDefault("MakesMetal", u.makesMetal);
 

--- a/src/rwe/sim/GameSimulation.h
+++ b/src/rwe/sim/GameSimulation.h
@@ -280,7 +280,15 @@ namespace rwe
 
         std::vector<GameEvent> events;
 
-        explicit GameSimulation(MapTerrain&& terrain, unsigned char surfaceMetal);
+        float currentWindGenerationFactor;
+
+        const int minWindSpeed;
+
+        const int maxWindSpeed;
+
+        GameTime nextWindSpeedChange;
+
+        explicit GameSimulation(MapTerrain&& terrain, unsigned char surfaceMetal, int minWindSpeed, int maxWindSpeed);
 
         std::optional<FeatureId> addFeature(MapFeature&& newFeature);
 
@@ -433,6 +441,8 @@ namespace rwe
         void killPlayer(PlayerId playerId);
 
         void processVictoryCondition();
+
+        void updateWind();
 
         void updateResources();
 

--- a/src/rwe/sim/UnitDefinition.h
+++ b/src/rwe/sim/UnitDefinition.h
@@ -119,6 +119,8 @@ namespace rwe
         Energy energyStorage;
         Metal metalStorage;
 
+        Energy windGenerator;
+
         std::optional<Grid<YardMapCell>> yardMap;
 
         std::string corpse;

--- a/src/rwe/util/OpaqueUnit.h
+++ b/src/rwe/util/OpaqueUnit.h
@@ -28,6 +28,12 @@ namespace rwe
             this->value -= b.value;
             return *this;
         };
+        OpaqueUnit<T, Tag> operator*(const OpaqueUnit<T, Tag>& b) const { return OpaqueUnit<T, Tag>(this->value * b.value); };
+        OpaqueUnit<T, Tag>& operator*=(const OpaqueUnit<T, Tag>& b)
+        {
+            this->value *= b.value;
+            return *this;
+        };
         OpaqueUnit<T, Tag> operator%(const OpaqueUnit<T, Tag>& b) const { return OpaqueUnit<T, Tag>(this->value % b.value); };
     };
 }


### PR DESCRIPTION
This PR adds support for units with the "WindGenerator" tag to generate energy and adds wind speed.

The wind speed changes between every 5 to 14 seconds to a new random value between the min and max wind speed of the map. I looked at the disassembly of the original exe and this is how I understood the behavior to be, but I'm not 100% certain.

![image](https://github.com/MHeasell/rwe/assets/14198435/3f59ed16-6047-4caa-b4ff-779827db87dd)
