### PR TITLE
Limit placement of geothermal units to geothermal vents

### DIFF
--- a/src/rwe/LoadingScene_util.cpp
+++ b/src/rwe/LoadingScene_util.cpp
@@ -320,6 +320,8 @@ namespace rwe
 
         u.soundCategory = fbi.soundCategory;
 
+        u.yardMapContainsGeo = false;
+
         auto movementClassId = movementClassDatabase.resolveMovementClassByName(fbi.movementClass);
 
         if (movementClassId)
@@ -341,6 +343,10 @@ namespace rwe
             if (u.yardMap->any(isWater))
             {
                 u.floater = true;
+            }
+            if (u.yardMap->any(isGeo))
+            {
+                u.yardMapContainsGeo = true;
             }
         }
 

--- a/src/rwe/game/GameScene.cpp
+++ b/src/rwe/game/GameScene.cpp
@@ -1887,7 +1887,7 @@ namespace rwe
                 const auto& unitDefinition = simulation.unitDefinitions.at(unitType);
                 auto mc = simulation.getAdHocMovementClass(unitDefinition.movementCollisionInfo);
                 auto footprintRect = simulation.computeFootprintRegion(pos, unitDefinition.movementCollisionInfo);
-                auto isValid = simulation.canBeBuiltAt(mc, unitDefinition.yardMapContainsGeo, footprintRect.x, footprintRect.y);
+                auto isValid = simulation.canBeBuiltAt(mc, unitDefinition.yardMap, unitDefinition.yardMapContainsGeo, footprintRect.x, footprintRect.y);
                 hoverBuildInfo = HoverBuildInfo{footprintRect, isValid};
             }
             else

--- a/src/rwe/game/GameScene.cpp
+++ b/src/rwe/game/GameScene.cpp
@@ -1887,7 +1887,7 @@ namespace rwe
                 const auto& unitDefinition = simulation.unitDefinitions.at(unitType);
                 auto mc = simulation.getAdHocMovementClass(unitDefinition.movementCollisionInfo);
                 auto footprintRect = simulation.computeFootprintRegion(pos, unitDefinition.movementCollisionInfo);
-                auto isValid = simulation.canBeBuiltAt(mc, footprintRect.x, footprintRect.y);
+                auto isValid = simulation.canBeBuiltAt(mc, unitDefinition.yardMapContainsGeo, footprintRect.x, footprintRect.y);
                 hoverBuildInfo = HoverBuildInfo{footprintRect, isValid};
             }
             else

--- a/src/rwe/sim/GameSimulation.cpp
+++ b/src/rwe/sim/GameSimulation.cpp
@@ -316,11 +316,9 @@ namespace rwe
         return unitId;
     }
 
-    bool GameSimulation::canBeBuiltAt(const rwe::MovementClassDefinition& mc, bool yardMapContainsGeo, unsigned int x, unsigned int y) const
+    bool GameSimulation::canBeBuiltAt(const rwe::MovementClassDefinition& mc, const std::optional<Grid<YardMapCell>>& yardMap, bool yardMapContainsGeo, unsigned int x, unsigned int y) const
     {
-        auto rect = DiscreteRect(x, y, mc.footprintX, mc.footprintZ);
-
-        if (isCollisionAt(rect))
+        if (isCollisionAt(DiscreteRect(x, y, mc.footprintX, mc.footprintZ)))
         {
             return false;
         }
@@ -330,7 +328,7 @@ namespace rwe
             return false;
         }
 
-        if (yardMapContainsGeo && !containsGeo(rect))
+        if (yardMapContainsGeo && yardMap && !containsAnyGeoMatch(*yardMap, x, y))
         {
             return false;
         }
@@ -371,9 +369,11 @@ namespace rwe
         });
     }
 
-    bool GameSimulation::containsGeo(const DiscreteRect& rect) const
+    bool GameSimulation::containsAnyGeoMatch(const Grid<YardMapCell>& yardMap, unsigned int x, unsigned int y) const
     {
-       return geoGrid.accumulate(geoGrid.clipRegion(rect), 0u, std::logical_or<>());
+        return geoGrid.any2(x, y, yardMap, [](const bool& geo, const YardMapCell& cell) {
+            return geo && isGeo(cell);
+        });
     }
 
     bool GameSimulation::isCollisionAt(const DiscreteRect& rect) const

--- a/src/rwe/sim/GameSimulation.h
+++ b/src/rwe/sim/GameSimulation.h
@@ -264,6 +264,8 @@ namespace rwe
 
         Grid<unsigned char> metalGrid;
 
+        Grid<bool> geoGrid;
+
         std::vector<GamePlayerInfo> players;
 
         VectorMap<MapFeature, FeatureIdTag> features;
@@ -307,15 +309,17 @@ namespace rwe
         /**
          * Returns true if a unit with the given movementclass attributes
          * could be built at given location on the map -- i.e. it is valid terrain
-         * for the unit and it is not occupied by something else.
+         * for the unit, it is not occupied by something else, and it contains geo if required.
          */
-        bool canBeBuiltAt(const MovementClassDefinition& mc, unsigned int x, unsigned int y) const;
+        bool canBeBuiltAt(const MovementClassDefinition& mc, bool yardMapContainsGeo, unsigned int x, unsigned int y) const;
 
         DiscreteRect computeFootprintRegion(const SimVector& position, unsigned int footprintX, unsigned int footprintZ) const;
 
         DiscreteRect computeFootprintRegion(const SimVector& position, const UnitDefinition::MovementCollisionInfo& collisionInfo) const;
 
         bool anyFeatureOccupies(const DiscreteRect& rect) const;
+
+        bool containsGeo(const DiscreteRect& rect) const;
 
         bool isCollisionAt(const DiscreteRect& rect) const;
 

--- a/src/rwe/sim/GameSimulation.h
+++ b/src/rwe/sim/GameSimulation.h
@@ -311,7 +311,7 @@ namespace rwe
          * could be built at given location on the map -- i.e. it is valid terrain
          * for the unit, it is not occupied by something else, and it contains geo if required.
          */
-        bool canBeBuiltAt(const MovementClassDefinition& mc, bool yardMapContainsGeo, unsigned int x, unsigned int y) const;
+        bool canBeBuiltAt(const MovementClassDefinition& mc, const std::optional<Grid<YardMapCell>>& yardMap, bool yardMapContainsGeo, unsigned int x, unsigned int y) const;
 
         DiscreteRect computeFootprintRegion(const SimVector& position, unsigned int footprintX, unsigned int footprintZ) const;
 
@@ -319,7 +319,7 @@ namespace rwe
 
         bool anyFeatureOccupies(const DiscreteRect& rect) const;
 
-        bool containsGeo(const DiscreteRect& rect) const;
+        bool containsAnyGeoMatch(const Grid<YardMapCell>& yardMap, unsigned int x, unsigned int y) const;
 
         bool isCollisionAt(const DiscreteRect& rect) const;
 

--- a/src/rwe/sim/UnitDefinition.h
+++ b/src/rwe/sim/UnitDefinition.h
@@ -122,6 +122,7 @@ namespace rwe
         Energy windGenerator;
 
         std::optional<Grid<YardMapCell>> yardMap;
+        bool yardMapContainsGeo;
 
         std::string corpse;
 

--- a/src/rwe/sim/UnitState.cpp
+++ b/src/rwe/sim/UnitState.cpp
@@ -34,6 +34,11 @@ namespace rwe
         }
     }
 
+    bool isGeo(YardMapCell cell)
+    {
+        return cell == YardMapCell::Geo;
+    }
+
     bool isPassable(YardMapCell cell, bool yardMapOpen)
     {
         switch (cell)

--- a/src/rwe/sim/UnitState.h
+++ b/src/rwe/sim/UnitState.h
@@ -141,6 +141,8 @@ namespace rwe
 
     bool isWater(YardMapCell cell);
 
+    bool isGeo(YardMapCell cell);
+
     bool isPassable(YardMapCell cell, bool yardMapOpen);
 
     struct SteeringInfo


### PR DESCRIPTION
This PR makes it so that units with `G` in their yard map only can be built on geothermal spots on the map.

https://github.com/MHeasell/rwe/assets/14198435/4d947b5c-2aae-4188-af39-cb3d0b01241f

The two geothermal power plants in TA have `YardMap=GGGGGGGGGGGGGGGG;` as their yard map. They can be built as long as any part of them intersect with a feature with `geothermal=1;`. In TA if their yard map is changed to for example `YardMap=Gooooooooooooooo;` their top left corner needs to be on a geothermal vent. And in TA with `YardMap=GooooooooooooooG;` as a yard map **either** their top left or bottom right corner needs to be on a thermal vent. Edit: This behavior should now be fully replicated in this PR, allowing for example the ProTA geothermal to work properly,