### PR TITLE
Work in progress

### DIFF
--- a/src/rwe/LoadingScene_util.cpp
+++ b/src/rwe/LoadingScene_util.cpp
@@ -158,6 +158,8 @@ namespace rwe
         weaponDefinition.burstInterval = SimScalar(tdf.burstRate);
         weaponDefinition.sprayAngle = SimAngle(tdf.sprayAngle);
 
+        weaponDefinition.energyPerShot = Energy(tdf.energyPerShot);
+
         if (tdf.tracks)
         {
             weaponDefinition.physicsType = ProjectilePhysicsTypeTracking{SimScalar(tdf.turnRate)};

--- a/src/rwe/sim/UnitBehaviorService.cpp
+++ b/src/rwe/sim/UnitBehaviorService.cpp
@@ -546,6 +546,8 @@ namespace rwe
 
         sim->events.push_back(FireWeaponEvent{weapon->weaponType, fireInfo->burstsFired, firingPoint});
 
+        sim->addResourceDelta(id, -weaponDefinition.energyPerShot, Metal(0));
+
         // If we just started the burst, set the reload timer
         if (fireInfo->burstsFired == 0)
         {

--- a/src/rwe/sim/WeaponDefinition.h
+++ b/src/rwe/sim/WeaponDefinition.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <rwe/sim/Energy.h>
 #include <rwe/sim/GameTime.h>
 #include <rwe/sim/ProjectilePhysicsType.h>
 #include <rwe/sim/SimAngle.h>
@@ -48,5 +49,7 @@ namespace rwe
 
         /** If true, projectile does not explode when hitting the ground but instead continues travelling. */
         bool groundBounce;
+
+        Energy energyPerShot;
     };
 }


### PR DESCRIPTION
## TA Behavior
- A unit with higher `energyPerShot` than the max energy storage of its player cannot fire its weapon 